### PR TITLE
chore: upgrade pnpm from 11.10.0 to 11.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "typescript-native": "npm:typescript@7.0.1-rc",
     "vite": "8.1.3"
   },
-  "packageManager": "pnpm@11.12.0",
+  "packageManager": "pnpm@11.10.0+sha512.0b7f8b98060031904c017e3a41eb187a16d40eeb829b95c4f8cb03681761fc4ab53dd219115b9b447f4dce1a05a214764461e7d3703392a9f32f9511ce8c86c8",
   "engines": {
     "node": ">=22.22.2",
     "pnpm": ">=9.0.0"

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "typescript-native": "npm:typescript@7.0.1-rc",
     "vite": "8.1.3"
   },
-  "packageManager": "pnpm@11.10.0",
+  "packageManager": "pnpm@11.12.0",
   "engines": {
     "node": ">=22.22.2",
     "pnpm": ">=9.0.0"


### PR DESCRIPTION
## Summary
Bump the `packageManager` field to the latest pnpm 11.x release (`11.12.0`). `pnpm/action-setup` in CI reads this field automatically. The `lockfileVersion: '9.0'` format is unaffected; `pnpm install` produced no lockfile changes.

## Test plan
- [x] `pnpm install` under pnpm 11.12.0 resolves identically (zero lockfile diff)
- [x] `pnpm run build`, `pnpm run test` pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01EZXTnGfYFgqbbEgYxRycrG)_