### PR TITLE
ci: skip steps instead of whole workflow so required checks pass on docs-only changes

### DIFF
--- a/.github/workflows/node-version-compatibility.yml
+++ b/.github/workflows/node-version-compatibility.yml
@@ -6,16 +6,7 @@ on:
       - 'develop'
       - 'develop*'
     paths-ignore:
-      - '**.md'
-      - '**.txt'
-      - 'agents/**'
-      - 'docs/**'
-      - 'documents/**'
       - '.gitignore'
-      - '.cspell.config.yaml'
-      - '.editorconfig'
-      - '.markdownlint-cli2.mjs'
-      - 'LICENSE'
 
   workflow_dispatch:
 
@@ -33,6 +24,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Fetch main
+        run: git fetch origin main # To allow check-should-run-type-checks to get the diff from main
+
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
@@ -45,11 +39,20 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --engine-strict
 
+      # NOTE: To include this workflow in the branch protection rule status check,
+      # skip each step instead of skipping the entire workflow with paths-ignore.
+      - name: Check diff
+        id: check_diff_type
+        run: pnpm exec check-should-run-type-checks
+
       - name: Verify installation
+        if: steps.check_diff_type.outputs.should_run == 'true'
         run: pnpm list
 
       - name: Build
+        if: steps.check_diff_type.outputs.should_run == 'true'
         run: pnpm run build
 
       - name: Test
+        if: steps.check_diff_type.outputs.should_run == 'true'
         run: pnpm run test


### PR DESCRIPTION
## Summary
The `test-node-versions (<version>)` jobs are required status checks in the main branch ruleset, but `node-version-compatibility.yml` was skipped entirely (via `paths-ignore`) on docs-only changes, leaving the required checks permanently pending and blocking merges. This mirrors the fix already applied in `ts-data-forge`.

## Changes

### `node-version-compatibility.yml`
- Removed the broad `paths-ignore` patterns so the workflow always runs and the required status checks always report (kept `.gitignore` only, matching `lint.yml`)
- Added `git fetch origin main` and a `check-should-run-type-checks` step that determines from the diff against main whether the checks need to run
- Gated the "Verify installation", "Build", and "Test" steps on `should_run == 'true'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAZE7Pfy1b3EgbWeEarKyT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAZE7Pfy1b3EgbWeEarKyT)_