### PR TITLE
fix(eslint-plugin): emit a non-empty-object type when no rule has options

### DIFF
--- a/packages/eslint-plugin-ts-type-forge/scripts/cmd/gen-rule-types.mts
+++ b/packages/eslint-plugin-ts-type-forge/scripts/cmd/gen-rule-types.mts
@@ -116,12 +116,22 @@ const generateFileContent = (rules: readonly RuleInfo[]): string => {
     ),
     '}>;',
     '',
-    'export type EslintTsTypeForgeRulesOption = Readonly<{',
-    ...optionRules.map(
-      (rule) =>
-        `  '${pluginPrefix}/${rule.name}': ${rule.namespaceName}.Options;`,
-    ),
-    '}>;',
+    // `Readonly<{}>` would be an "empty object" type (any non-nullish value),
+    // so the no-option case gets an explicitly empty record instead.
+    ...(optionRules.length === 0
+      ? [
+          'export type EslintTsTypeForgeRulesOption = Readonly<',
+          '  Record<never, never>',
+          '>;',
+        ]
+      : [
+          'export type EslintTsTypeForgeRulesOption = Readonly<{',
+          ...optionRules.map(
+            (rule) =>
+              `  '${pluginPrefix}/${rule.name}': ${rule.namespaceName}.Options;`,
+          ),
+          '}>;',
+        ]),
     '',
     '// If this assertion fails to type-check, this generated file has drifted from',
     '// the actual plugin rules — re-run `pnpm run gen:rule-types`.',


### PR DESCRIPTION
## Summary

`scripts/cmd/gen-rule-types.mts` unconditionally emitted

```ts
export type EslintTsTypeForgeRulesOption = Readonly<{
  /* one entry per rule that declares options */
}>;
```

which collapses to `Readonly<{}>` when **no** rule declares options. `{}` is the
"empty object" type — it accepts any non-nullish value, including `0` and `''` —
so the generated file fails `@typescript-eslint/no-empty-object-type` and the
package cannot lint.

## Why it hasn't bitten this repo yet

`prefer-non-empty-array` has an `importStyle` option, so `optionRules` is
non-empty and the bad branch is never taken. The bug surfaces the moment the
plugin ships only option-less rules — which is exactly what happened when the
same generator was reused for `eslint-plugin-ts-fortress`, whose first rule has
`schema: []`.

## Change

Emit `Readonly<Record<never, never>>` for the no-options case, keeping the
existing object literal otherwise. Regenerating `src/rule-types.mts` on `main`
produces no diff, so this is a pure future-proofing fix.

## Notes

No changeset: this only touches a build-time script, and the published output is
byte-identical for the current rule set.

## Verification

- `pnpm run gen:rule-types` → `src/rule-types.mts` unchanged
- `pnpm run check:root`, plugin `tsc --noEmit`, plugin `eslint .` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vc6fWvHXu4dKzmED1HujD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vc6fWvHXu4dKzmED1HujD4)_