### PR TITLE
refactor: derive the negated condition types from their positive ones

### DIFF
--- a/.changeset/boolean-utils-refactor.md
+++ b/.changeset/boolean-utils-refactor.md
@@ -1,0 +1,22 @@
+---
+'ts-type-forge': patch
+---
+
+Define the negated condition types in terms of their positive counterparts
+instead of re-spelling the underlying trick, and `IsNever` in terms of
+`TypeExtends`:
+
+| type                      | before                                      | after                           |
+| :------------------------ | :------------------------------------------ | :------------------------------ |
+| `IsNotAny<T>`             | `0 extends 1 & T ? false : true`            | `BoolNot<IsAny<T>>`             |
+| `IsNotUnknown<T>`         | `IsUnknown<T> extends true ? false : true`  | `BoolNot<IsUnknown<T>>`         |
+| `IsNotFixedLengthList<T>` | `number extends T['length'] ? true : false` | `BoolNot<IsFixedLengthList<T>>` |
+| `IsNever<T>`              | `[T] extends [never] ? true : false`        | `TypeExtends<T, never>`         |
+
+Each `IsNot*` previously duplicated the detection logic of its positive
+counterpart, so the two could drift; they are now derived from it, which is
+also what their documentation already claimed. `IsNever` was character-for-
+character the definition of `TypeExtends<T, never>`.
+
+Behavior is unchanged — the existing type tests for all four cover `any`,
+`never`, `unknown`, unions, tuples and arrays.

--- a/packages/ts-type-forge/README.md
+++ b/packages/ts-type-forge/README.md
@@ -612,18 +612,18 @@ For detailed information on all types, see the [Full API Reference](./docs/READM
 - src/condition/extends.mts
     - [TypeExtends](./src/condition/extends.mts#L45)
 - src/condition/is-any.mts
-    - [IsAny](./src/condition/is-any.mts#L19)
-    - [IsNotAny](./src/condition/is-any.mts#L33)
+    - [IsAny](./src/condition/is-any.mts#L21)
+    - [IsNotAny](./src/condition/is-any.mts#L35)
 - src/condition/is-fixed-length-list.mts
-    - [IsFixedLengthList](./src/condition/is-fixed-length-list.mts#L19)
-    - [IsNotFixedLengthList](./src/condition/is-fixed-length-list.mts#L37)
+    - [IsFixedLengthList](./src/condition/is-fixed-length-list.mts#L21)
+    - [IsNotFixedLengthList](./src/condition/is-fixed-length-list.mts#L39)
 - src/condition/is-never.mts
-    - [IsNever](./src/condition/is-never.mts#L18)
+    - [IsNever](./src/condition/is-never.mts#L20)
 - src/condition/is-union.mts
     - [IsUnion](./src/condition/is-union.mts#L30)
 - src/condition/is-unknown.mts
-    - [IsUnknown](./src/condition/is-unknown.mts#L20)
-    - [IsNotUnknown](./src/condition/is-unknown.mts#L35)
+    - [IsUnknown](./src/condition/is-unknown.mts#L21)
+    - [IsNotUnknown](./src/condition/is-unknown.mts#L36)
 - src/constants/alphabet.mts
     - [LowerAlphabet](./src/constants/alphabet.mts#L21)
     - [UpperAlphabet](./src/constants/alphabet.mts#L48)

--- a/packages/ts-type-forge/src/condition/is-any.mts
+++ b/packages/ts-type-forge/src/condition/is-any.mts
@@ -1,3 +1,5 @@
+import { type BoolNot } from '../others/index.mjs';
+
 /**
  * Checks if a given type `T` is exactly the `any` type.
  *
@@ -30,4 +32,4 @@ export type IsAny<T> = 0 extends 1 & T ? true : false;
  * type T2 = IsNotAny<unknown>; // true
  * type T3 = IsNotAny<string>; // true
  */
-export type IsNotAny<T> = 0 extends 1 & T ? false : true;
+export type IsNotAny<T> = BoolNot<IsAny<T>>;

--- a/packages/ts-type-forge/src/condition/is-fixed-length-list.mts
+++ b/packages/ts-type-forge/src/condition/is-fixed-length-list.mts
@@ -1,3 +1,5 @@
+import { type BoolNot } from '../others/index.mjs';
+
 /**
  * Checks if a given readonly array type `T` has a fixed length (i.e., is a tuple).
  * Returns `true` if `T` is a tuple, `false` if it's a regular array (`Type[]`).
@@ -34,5 +36,6 @@ export type IsFixedLengthList<T extends readonly unknown[]> =
  * type IsNotEmptyTuple = IsNotFixedLengthList<[]>; // false
  * type IsNotTupleWithRest = IsNotFixedLengthList<[number, ...string[]]>; // true
  */
-export type IsNotFixedLengthList<T extends readonly unknown[]> =
-  number extends T['length'] ? true : false;
+export type IsNotFixedLengthList<T extends readonly unknown[]> = BoolNot<
+  IsFixedLengthList<T>
+>;

--- a/packages/ts-type-forge/src/condition/is-never.mts
+++ b/packages/ts-type-forge/src/condition/is-never.mts
@@ -1,3 +1,5 @@
+import { type TypeExtends } from './extends.mjs';
+
 /**
  * Checks if a given type `T` is exactly the `never` type.
  *
@@ -15,4 +17,4 @@
  * type T5 = IsNever<string | never>; // false (evaluates to string)
  * type T6 = IsNever<string & never>; // true (evaluates to never)
  */
-export type IsNever<T> = [T] extends [never] ? true : false;
+export type IsNever<T> = TypeExtends<T, never>;

--- a/packages/ts-type-forge/src/condition/is-unknown.mts
+++ b/packages/ts-type-forge/src/condition/is-unknown.mts
@@ -1,3 +1,4 @@
+import { type BoolNot } from '../others/index.mjs';
 import { type IsAny } from './is-any.mjs';
 
 /**
@@ -32,4 +33,4 @@ export type IsUnknown<T> =
  * type T2 = IsNotUnknown<any>; // true
  * type T3 = IsNotUnknown<string>; // true
  */
-export type IsNotUnknown<T> = IsUnknown<T> extends true ? false : true;
+export type IsNotUnknown<T> = BoolNot<IsUnknown<T>>;


### PR DESCRIPTION
Each `IsNot*` re-spelled the detection logic of its positive counterpart rather than negating it, so the two could drift — even though their documentation already described them as "the logical negation of" the positive one. `IsNever` was character-for-character the definition of `TypeExtends<T, never>`.

| type | before | after |
| :--- | :--- | :--- |
| `IsNotAny<T>` | `0 extends 1 & T ? false : true` | `BoolNot<IsAny<T>>` |
| `IsNotUnknown<T>` | `IsUnknown<T> extends true ? false : true` | `BoolNot<IsUnknown<T>>` |
| `IsNotFixedLengthList<T>` | `number extends T['length'] ? true : false` | `BoolNot<IsFixedLengthList<T>>` |
| `IsNever<T>` | `[T] extends [never] ? true : false` | `TypeExtends<T, never>` |

The first three each carried a second, independent copy of the trick that makes the positive type work — `IsNotAny` repeated the `0 extends 1 & T` idiom, `IsNotFixedLengthList` repeated the `number extends T['length']` idiom. Deriving them removes that duplication.

## Notes for review

- **Import direction**: this makes `condition/is-any`, `condition/is-unknown` and `condition/is-fixed-length-list` import `BoolNot` from `others/`. That is the same direction `condition/is-union.mts` already uses for `BoolNot`, and `import-x/no-cycle` stays clean. `IsNever` only picks up a same-directory import (`./extends.mjs`).
- **`TypeExtends` vs a bare conditional**: `TypeExtends<A, B>` is `[A] extends [B] ? true : false`, i.e. the tuple-wrapped, non-distributive form — which is exactly what `IsNever` already wrote by hand, so the substitution is literal.
- **Behavior**: unchanged. The existing type tests for all four types cover `any`, `never`, `unknown`, unions, tuples, arrays and empty tuples, and pass untouched.

Split out from noshiro-pf/ts-type-forge#442 (which applies the same utilities to the new bounds module it introduces) because this touches unrelated, pre-existing types.

## Validation

`ws:build` (including the dist type-checks through the package `exports` map), `ws:test`, `ws:lint:fix`, `ws:doc`, `cspell`, `md`, `codemod:full`, `fmt` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vc6fWvHXu4dKzmED1HujD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vc6fWvHXu4dKzmED1HujD4)_