### PR TITLE
fix!: lead MakeTuple and SetAt with the length and the index

### DIFF
--- a/.changeset/constrained-list-ops.md
+++ b/.changeset/constrained-list-ops.md
@@ -102,7 +102,7 @@ that makes `List.Tail` of such a type `readonly unknown[]`, and makes
 instantiation-depth limit outright. Indexed access _does_ reach through, so
 the tuple is rebuilt one index at a time, capped at 32 elements; past the cap
 the brand answer stands alone, which claims less rather than more. `List` and
-`Tuple` themselves are unchanged — the type tests now pin their behaviour on
+`Tuple` themselves are unchanged — the type tests now pin their behavior on
 such an input so the gap stays visible.
 
 Cost of the rebuild across this package's own suite: **+18.5k instantiations,

--- a/.changeset/type-param-order.md
+++ b/.changeset/type-param-order.md
@@ -1,0 +1,37 @@
+---
+'ts-type-forge': major
+---
+
+**`MakeTuple` and `SetAt` now take their length / index first, like the rest of
+the library.**
+
+Every other length-parameterized array or tuple type here puts the length
+first — `MinLengthArray<MinLength, Elm>`, `BoundedLengthTuple<Min, Max, Elm>`,
+`FixedLengthTuple<N, Elm>` — and within `List` / `Tuple` the count-taking
+operations do too: `Take<N, T>`, `Skip<N, T>`, `TakeLast<N, T>`,
+`SkipLast<N, T>`, `Partition<N, T>`. Two members were out of step:
+
+| type                              | before        | after                             |
+| :-------------------------------- | :------------ | :-------------------------------- |
+| `MakeTuple<Elm, N>`               | element first | `MakeTuple<N, Elm>`               |
+| `List.SetAt<T, I, V>`             | array first   | `List.SetAt<I, V, T>`             |
+| `Tuple.SetAt<T, I, V>`            | array first   | `Tuple.SetAt<I, V, T>`            |
+| `ConstrainedList.SetAt<Ar, I, V>` | array first   | `ConstrainedList.SetAt<I, V, Ar>` |
+
+`MakeTuple` was the more visible of the two, because the swap showed up in the
+library's own source: `FixedLengthTuple<N, Elm> = MakeTuple<Elm, N>`. It now
+reads `MakeTuple<N, Elm>`.
+
+`SetAt` was the only count-taking `List` / `Tuple` operation that led with the
+array, so `List.SetAt<[1, 2, 3], 1, 'x'>` sat next to `List.Take<2, [1, 2, 3]>`
+with the array on the opposite side. It now reads `List.SetAt<1, 'x', [1, 2, 3]>`.
+
+BREAKING CHANGE: `MakeTuple`, `List.SetAt`, `Tuple.SetAt` and
+`ConstrainedList.SetAt` reorder their type parameters. Every use site must
+swap its arguments — `MakeTuple<string, 3>` becomes `MakeTuple<3, string>`, and
+`List.SetAt<T, I, V>` becomes `List.SetAt<I, V, T>`. These are types, so there
+is no inference to fall back on: the compiler reports each site.
+
+`List.Head<T, D>` is deliberately unchanged — `D` is a fallback rather than a
+count, and it is defaulted, so leading with it would make the common
+one-argument form impossible to write.

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "codemod:full:readonly": "convert-to-readonly 'packages/*/{scripts,test}/**/*.{mts,tsx}'",
     "codemod:uncommitted:as-const": "append-as-const --uncommitted 'packages/*/{scripts,test}/**/*.{mts,tsx}'",
     "codemod:uncommitted:readonly": "convert-to-readonly --uncommitted 'packages/*/{scripts,test}/**/*.{mts,tsx}'",
-    "cspell": "cspell \"**\" --gitignore --gitignore-root ./ --no-progress",
+    "cspell": "cspell \"{**/*,.changeset/**/*}\" --gitignore --gitignore-root ./ --no-progress",
     "fmt": "format-uncommitted",
     "fmt:diff": "format-diff-from origin/main",
     "fmt:full": "prettier --ignore-unknown --no-error-on-unmatched-pattern --write .",

--- a/packages/ts-type-forge/samples/src/branded-types/predefined-arrays/max-length-array-example.mts
+++ b/packages/ts-type-forge/samples/src/branded-types/predefined-arrays/max-length-array-example.mts
@@ -3,8 +3,8 @@ import { type MaxLengthArray, type SupportedLength } from 'ts-type-forge';
 // embed-sample-code-ignore-above
 
 const isMaxLengthArray = <N extends SupportedLength, E>(
-  xs: readonly E[],
   maxLength: N,
+  xs: readonly E[],
 ): xs is MaxLengthArray<N, E> => xs.length <= maxLength;
 
 const tags = ['a', 'b', 'c'] as unknown as MaxLengthArray<8, string>;

--- a/packages/ts-type-forge/samples/src/branded-types/predefined-arrays/min-length-array-example.mts
+++ b/packages/ts-type-forge/samples/src/branded-types/predefined-arrays/min-length-array-example.mts
@@ -3,8 +3,8 @@ import { type MinLengthArray, type SupportedLength } from 'ts-type-forge';
 // embed-sample-code-ignore-above
 
 const isMinLengthArray = <N extends SupportedLength, E>(
-  xs: readonly E[],
   minLength: N,
+  xs: readonly E[],
 ): xs is MinLengthArray<N, E> => xs.length >= minLength;
 
 const history = [0, 1, 2, 3] as unknown as MinLengthArray<3, number>;

--- a/packages/ts-type-forge/src/branded-types/predefined-arrays/length-constrained-array-ops.mts
+++ b/packages/ts-type-forge/src/branded-types/predefined-arrays/length-constrained-array-ops.mts
@@ -108,14 +108,14 @@ export namespace ConstrainedList {
    * Replaces the element at index `I` of `Ar` with `V`, keeping its length
    * constraint. Like {@link Reverse}, this changes no length.
    *
-   * @template Ar - The array type to update.
    * @template I - The index to update.
    * @template V - The new type at that index.
+   * @template Ar - The array type to update.
    */
-  export type SetAt<Ar extends readonly unknown[], I extends number, V> =
+  export type SetAt<I extends number, V, Ar extends readonly unknown[]> =
     HasLengthConstraint<Ar> extends true
       ? ChangeArrayElement<Ar, Ar[number] | V> & SetAtStructure<Ar, I, V>
-      : List.SetAt<Ar, I, V>;
+      : List.SetAt<I, V, Ar>;
 
   /**
    * Drops the first element of `Ar`, lowering both bounds by one.
@@ -431,7 +431,7 @@ type ReverseStructure<Ar extends readonly unknown[]> =
 /** @internal {@link List.SetAt} of the exact tuple, when there is one. */
 type SetAtStructure<Ar extends readonly unknown[], I extends number, V> =
   PinsExactTuple<Ar> extends true
-    ? List.SetAt<MaterializeTuple<Ar>, I, V>
+    ? List.SetAt<I, V, MaterializeTuple<Ar>>
     : unknown;
 
 /** @internal {@link List.Tail} of the exact tuple, when there is one. */
@@ -589,4 +589,4 @@ type SmallerLength<A, B> =
  * constraint satisfied for a bound that is still deferred on a type parameter,
  * which is the normal case here.
  */
-type LengthTuple<N> = MakeTuple<0, N & number>;
+type LengthTuple<N> = MakeTuple<N & number, 0>;

--- a/packages/ts-type-forge/src/branded-types/predefined-arrays/length-constrained-array-ops.test.mts
+++ b/packages/ts-type-forge/src/branded-types/predefined-arrays/length-constrained-array-ops.test.mts
@@ -260,12 +260,12 @@ expectType<
 /* SetAt */
 
 expectType<
-  ConstrainedList.SetAt<MinLengthArray<3, number>, 1, 'x'>,
+  ConstrainedList.SetAt<1, 'x', MinLengthArray<3, number>>,
   MinLengthArray<3, number | 'x'>
 >('~=');
 
 expectType<
-  ConstrainedList.SetAt<readonly [1, 2, 3], 1, 'x'>,
+  ConstrainedList.SetAt<1, 'x', readonly [1, 2, 3]>,
   readonly [1, 'x', 3]
 >('=');
 
@@ -466,7 +466,7 @@ expectType<
 >('~=');
 
 expectType<
-  ConstrainedList.SetAt<BrandedFiveTuple, 1, 'x'>,
+  ConstrainedList.SetAt<1, 'x', BrandedFiveTuple>,
   MinLengthArray<3, Elm5 | 'x'> & readonly [1, 'x', 3, 4, 5]
 >('~=');
 
@@ -580,7 +580,7 @@ expectType<List.Last<readonly [1, 2, 3, 4, 5]>, 5>('=');
 export type ListReverseOfBranded = List.Reverse<BrandedFiveTuple>;
 
 // @ts-expect-error TS2589: Type instantiation is excessively deep.
-export type ListSetAtOfBranded = List.SetAt<BrandedFiveTuple, 1, 'x'>;
+export type ListSetAtOfBranded = List.SetAt<1, 'x', BrandedFiveTuple>;
 
 // @ts-expect-error TS2589: Type instantiation is excessively deep.
 export type ListPartitionOfBranded = List.Partition<2, BrandedFiveTuple>;

--- a/packages/ts-type-forge/src/branded-types/predefined-arrays/length-constrained-array.mts
+++ b/packages/ts-type-forge/src/branded-types/predefined-arrays/length-constrained-array.mts
@@ -73,8 +73,8 @@ type ClampToPrefixCap<N extends number> =
  * @example
  * ```ts
  * const isMaxLengthArray = <N extends SupportedLength, E>(
- *   xs: readonly E[],
  *   maxLength: N,
+ *   xs: readonly E[],
  * ): xs is MaxLengthArray<N, E> => xs.length <= maxLength;
  *
  * const tags = ['a', 'b', 'c'] as unknown as MaxLengthArray<8, string>;
@@ -177,8 +177,8 @@ export type MutableMaxLengthArray<
  * @example
  * ```ts
  * const isMinLengthArray = <N extends SupportedLength, E>(
- *   xs: readonly E[],
  *   minLength: N,
+ *   xs: readonly E[],
  * ): xs is MinLengthArray<N, E> => xs.length >= minLength;
  *
  * const history = [0, 1, 2, 3] as unknown as MinLengthArray<3, number>;

--- a/packages/ts-type-forge/src/global.mts
+++ b/packages/ts-type-forge/src/global.mts
@@ -405,7 +405,7 @@ declare global {
     N extends number,
     Elm,
   > = _TSTypeForge.MutableMaxLengthTuple<N, Elm>;
-  type MakeTuple<Elm, N extends number> = _TSTypeForge.MakeTuple<Elm, N>;
+  type MakeTuple<N extends number, Elm> = _TSTypeForge.MakeTuple<N, Elm>;
   type AbsoluteValue<N extends number> = _TSTypeForge.AbsoluteValue<N>;
   type Abs<N extends number> = _TSTypeForge.Abs<N>;
   type Increment<N extends number> = _TSTypeForge.Increment<N>;
@@ -436,10 +436,10 @@ declare global {
     export type Reverse<Ar extends readonly unknown[]> =
       _TSTypeForge.ConstrainedList.Reverse<Ar>;
     export type SetAt<
-      Ar extends readonly unknown[],
       I extends number,
       V,
-    > = _TSTypeForge.ConstrainedList.SetAt<Ar, I, V>;
+      Ar extends readonly unknown[],
+    > = _TSTypeForge.ConstrainedList.SetAt<I, V, Ar>;
     export type Tail<Ar extends readonly unknown[]> =
       _TSTypeForge.ConstrainedList.Tail<Ar>;
     export type ButLast<Ar extends readonly unknown[]> =
@@ -507,10 +507,10 @@ declare global {
       T extends readonly unknown[],
     > = _TSTypeForge.List.SkipLast<N, T>;
     export type SetAt<
-      T extends readonly unknown[],
       I extends number,
       V,
-    > = _TSTypeForge.List.SetAt<T, I, V>;
+      T extends readonly unknown[],
+    > = _TSTypeForge.List.SetAt<I, V, T>;
     export type Flatten<T extends readonly (readonly unknown[])[]> =
       _TSTypeForge.List.Flatten<T>;
     export type Concat<
@@ -554,10 +554,10 @@ declare global {
       T extends readonly unknown[],
     > = _TSTypeForge.Tuple.SkipLast<N, T>;
     export type SetAt<
-      T extends readonly unknown[],
       I extends number,
       V,
-    > = _TSTypeForge.Tuple.SetAt<T, I, V>;
+      T extends readonly unknown[],
+    > = _TSTypeForge.Tuple.SetAt<I, V, T>;
     export type Flatten<T extends readonly (readonly unknown[])[]> =
       _TSTypeForge.Tuple.Flatten<T>;
     export type Concat<

--- a/packages/ts-type-forge/src/record/record-path.mts
+++ b/packages/ts-type-forge/src/record/record-path.mts
@@ -280,7 +280,7 @@ type RecordUpdatedImplTupleCase<
   ? Head extends IndexOfTuple<T> // Is the head a valid numeric index for the tuple?
     ? Rest extends RecordPaths<T[Head]> // Is the rest a valid path within the nested value?
       ? // Use Tuple.SetAt to update the element at the specific index
-        Tuple.SetAt<T, Head, RecordUpdated<T[Head], Rest, ValueAfter>>
+        Tuple.SetAt<Head, RecordUpdated<T[Head], Rest, ValueAfter>, T>
       : never // Invalid rest path
     : never // Invalid head index
   : never; // Path should not be empty here (handled in RecordUpdated)

--- a/packages/ts-type-forge/src/tuple-and-list/length-constrained-tuple.mts
+++ b/packages/ts-type-forge/src/tuple-and-list/length-constrained-tuple.mts
@@ -7,7 +7,7 @@ import { type MakeTuple } from './make-tuple.mjs';
 
 /**
  * Creates a readonly tuple type of a specific length `N` with elements of type `Elm`.
- * Alias for `MakeTuple<Elm, N>`.
+ * Alias for `MakeTuple<N, Elm>`.
  * @template N - The desired length of the tuple (must be a non-negative integer literal).
  * @template Elm - The type of elements in the tuple.
  * @returns A readonly tuple type `readonly [Elm, Elm, ..., Elm]` of length `N`.
@@ -15,7 +15,7 @@ import { type MakeTuple } from './make-tuple.mjs';
  * type TupleOf3Strings = FixedLengthTuple<3, string>; // readonly [string, string, string]
  * type TupleOf0Numbers = FixedLengthTuple<0, number>; // readonly []
  */
-export type FixedLengthTuple<N extends number, Elm> = MakeTuple<Elm, N>;
+export type FixedLengthTuple<N extends number, Elm> = MakeTuple<N, Elm>;
 
 /**
  * Creates a mutable tuple type of a specific length `N` with elements of type `Elm`.
@@ -60,7 +60,7 @@ export type MutableMinLengthTuple<N extends number, Elm> = Mutable<
  * // const invalid: AtLeast3Strings = ["a", "b"]; // Error
  */
 export type MinLengthTuple<N extends number, Elm> = readonly [
-  ...MakeTuple<Elm, N>,
+  ...MakeTuple<N, Elm>,
   ...Elm[],
 ];
 
@@ -91,7 +91,7 @@ type TuplePrefixesDownTo<
 /**
  * Creates a readonly tuple type whose length is between `Min` and `Max` (both inclusive).
  * The result is a union of fixed-length readonly tuples
- * `MakeTuple<Elm, Min> | ... | MakeTuple<Elm, Max>`.
+ * `MakeTuple<Min, Elm> | ... | MakeTuple<Max, Elm>`.
  * Requires `Min` and `Max` to be non-negative integer literals with `Min <= Max`.
  *
  * @template Min - The minimum length (inclusive). Must be a non-negative integer literal.
@@ -110,7 +110,7 @@ export type BoundedLengthTuple<
   Min extends number,
   Max extends number,
   Elm,
-> = TuplePrefixesDownTo<MakeTuple<Elm, Max>, Min>;
+> = TuplePrefixesDownTo<MakeTuple<Max, Elm>, Min>;
 
 /**
  * Mutable version of {@link BoundedLengthTuple}.
@@ -133,7 +133,7 @@ export type MutableBoundedLengthTuple<
 /**
  * Creates a readonly tuple type whose length is at most `N` (i.e. `0` to `N`, both inclusive).
  * Counterpart of {@link MinLengthTuple}, defined as `BoundedLengthTuple<0, N, Elm>`.
- * The result is a union `readonly [] | readonly [Elm] | ... | MakeTuple<Elm, N>`.
+ * The result is a union `readonly [] | readonly [Elm] | ... | MakeTuple<N, Elm>`.
  * Requires `N` to be a non-negative integer literal.
  *
  * @template N - The maximum length (inclusive). Must be a non-negative integer literal.

--- a/packages/ts-type-forge/src/tuple-and-list/list.mts
+++ b/packages/ts-type-forge/src/tuple-and-list/list.mts
@@ -140,18 +140,18 @@ export namespace List {
    * Creates a new array/tuple type where the element at index `I` in `T` is replaced with type `V`.
    * If `T` is a tuple, it returns a new tuple type with the element at `I` updated.
    * If `T` is a general array, it returns a general array type `readonly (T[number] | V)[]`.
-   * @template T - The readonly array or tuple type.
    * @template I - The index to update (must be a valid index for `T` if `T` is a tuple).
    * @template V - The new type for the element at index `I`.
+   * @template T - The readonly array or tuple type.
    * @returns A new array/tuple type with the element at index `I` updated.
    * @example
-   * type SA1 = List.SetAt<[1, 2, 3], 1, 'x'>; // readonly [1, 'x', 3]
-   * type SA2 = List.SetAt<readonly number[], 1, 'x'>; // readonly (string | number)[]
-   * // type SA3 = List.SetAt<[1, 2], 2, 'x'>; // Error if I is out of bounds for tuple
+   * type SA1 = List.SetAt<1, 'x', [1, 2, 3]>; // readonly [1, 'x', 3]
+   * type SA2 = List.SetAt<1, 'x', readonly number[]>; // readonly (string | number)[]
+   * // type SA3 = List.SetAt<2, 'x', [1, 2]>; // Error if I is out of bounds for tuple
    */
-  export type SetAt<T extends readonly unknown[], I extends number, V> =
+  export type SetAt<I extends number, V, T extends readonly unknown[]> =
     IsFixedLengthList<T> extends true
-      ? Tuple.SetAt<T, I, V>
+      ? Tuple.SetAt<I, V, T>
       : readonly (T[number] | V)[];
 
   /**

--- a/packages/ts-type-forge/src/tuple-and-list/list.test.mts
+++ b/packages/ts-type-forge/src/tuple-and-list/list.test.mts
@@ -190,13 +190,13 @@ import { type List } from './list.mjs';
 
 // ── set-at ─────────────────────────
 {
-  expectType<List.SetAt<readonly [], 2, 999>, readonly []>('=');
+  expectType<List.SetAt<2, 999, readonly []>, readonly []>('=');
 
-  expectType<List.SetAt<readonly [1, 2], 2, 999>, readonly [1, 2]>('=');
+  expectType<List.SetAt<2, 999, readonly [1, 2]>, readonly [1, 2]>('=');
 
-  expectType<List.SetAt<readonly [1, 2, 3], 1, 999>, readonly [1, 999, 3]>('=');
+  expectType<List.SetAt<1, 999, readonly [1, 2, 3]>, readonly [1, 999, 3]>('=');
 
-  expectType<List.SetAt<readonly [1, 2, 3], 0, 999>, readonly [999, 2, 3]>('=');
+  expectType<List.SetAt<0, 999, readonly [1, 2, 3]>, readonly [999, 2, 3]>('=');
 }
 
 // ── skip-last ─────────────────────────

--- a/packages/ts-type-forge/src/tuple-and-list/make-tuple.mts
+++ b/packages/ts-type-forge/src/tuple-and-list/make-tuple.mts
@@ -1,16 +1,16 @@
 /**
  * Creates a readonly tuple type of a specific length `N` with elements of type `Elm`.
  *
- * @template Elm - The type of elements in the tuple.
  * @template N - The desired length of the tuple (must be a non-negative integer literal).
+ * @template Elm - The type of elements in the tuple.
  * @returns A readonly tuple type `readonly [Elm, Elm, ..., Elm]` of length `N`.
  * @example
- * type TupleOf3Strings = MakeTuple<string, 3>; // readonly [string, string, string]
- * type TupleOf0Numbers = MakeTuple<number, 0>; // readonly []
- * // type InvalidLength = MakeTuple<boolean, -1>; // Error or unexpected result
- * // type InvalidLength2 = MakeTuple<boolean, 1.5>; // Error or unexpected result
+ * type TupleOf3Strings = MakeTuple<3, string>; // readonly [string, string, string]
+ * type TupleOf0Numbers = MakeTuple<0, number>; // readonly []
+ * // type InvalidLength = MakeTuple<-1, boolean>; // Error or unexpected result
+ * // type InvalidLength2 = MakeTuple<1.5, boolean>; // Error or unexpected result
  */
-export type MakeTuple<Elm, N extends number> = MakeTupleImpl<Elm, `${N}`, []>;
+export type MakeTuple<N extends number, Elm> = MakeTupleImpl<Elm, `${N}`, []>;
 
 // https://techracho.bpsinc.jp/yoshi/2020_09_04/97108
 

--- a/packages/ts-type-forge/src/tuple-and-list/make-tuple.test.mts
+++ b/packages/ts-type-forge/src/tuple-and-list/make-tuple.test.mts
@@ -1,21 +1,21 @@
 import { expectType } from 'ts-data-forge';
 import { type MakeTuple } from './make-tuple.mjs';
 
-expectType<MakeTuple<unknown, 3>, readonly [unknown, unknown, unknown]>('=');
+expectType<MakeTuple<3, unknown>, readonly [unknown, unknown, unknown]>('=');
 
-expectType<MakeTuple<null, 0>, readonly []>('=');
+expectType<MakeTuple<0, null>, readonly []>('=');
 
-expectType<MakeTuple<3, 5>, readonly [3, 3, 3, 3, 3]>('=');
+expectType<MakeTuple<5, 3>, readonly [3, 3, 3, 3, 3]>('=');
 
 // Large tuple (also a smoke test against instantiation-depth limits)
-expectType<MakeTuple<0, 1000>['length'], 1000>('=');
+expectType<MakeTuple<1000, 0>['length'], 1000>('=');
 
 // Documents the actual compiler limit that `SupportedLengthCap` (2048) stays
 // safely below: tuple types are capped at 10,000 elements, so `MakeTuple`
 // works up to N = 9999 and fails with TS2799 ("Type produces a tuple type
 // that is too large to represent") from N = 10000.
 
-expectType<MakeTuple<unknown, 9999>['length'], 9999>('=');
+expectType<MakeTuple<9999, unknown>['length'], 9999>('=');
 
 // @ts-expect-error TS2799: tuple type too large to represent (N >= 10000)
-expectType<MakeTuple<unknown, 10000>['length'], 10000>('=');
+expectType<MakeTuple<10000, unknown>['length'], 10000>('=');

--- a/packages/ts-type-forge/src/tuple-and-list/tuple.mts
+++ b/packages/ts-type-forge/src/tuple-and-list/tuple.mts
@@ -158,18 +158,18 @@ export namespace Tuple {
 
   /**
    * Creates a new readonly tuple type where the element at index `I` in `T` is replaced with type `V`.
-   * @template T - The readonly tuple type.
    * @template I - The index to update (must be a valid index literal for `T`).
    * @template V - The new type for the element at index `I`.
+   * @template T - The readonly tuple type.
    * @returns A new readonly tuple type with the element at index `I` updated.
    * @example
-   * type SA1 = Tuple.SetAt<[1, 2, 3], 1, 'x'>; // readonly [1, 'x', 3]
-   * // type SA2 = Tuple.SetAt<[1, 2], 2, 'x'>; // Error: Index '2' is out of bounds.
+   * type SA1 = Tuple.SetAt<1, 'x', [1, 2, 3]>; // readonly [1, 'x', 3]
+   * // type SA2 = Tuple.SetAt<2, 'x', [1, 2]>; // Error: Index '2' is out of bounds.
    */
   export type SetAt<
-    T extends readonly unknown[],
     I extends number,
     V,
+    T extends readonly unknown[],
   > = SetAtImpl<T, I, V, readonly []>;
 
   /**

--- a/packages/ts-type-forge/src/tuple-and-list/tuple.test.mts
+++ b/packages/ts-type-forge/src/tuple-and-list/tuple.test.mts
@@ -128,15 +128,15 @@ import { type Tuple } from './tuple.mjs';
 
 // ── set-at ─────────────────────────
 {
-  expectType<Tuple.SetAt<readonly [], 2, 999>, readonly []>('=');
+  expectType<Tuple.SetAt<2, 999, readonly []>, readonly []>('=');
 
-  expectType<Tuple.SetAt<readonly [1, 2], 2, 999>, readonly [1, 2]>('=');
+  expectType<Tuple.SetAt<2, 999, readonly [1, 2]>, readonly [1, 2]>('=');
 
-  expectType<Tuple.SetAt<readonly [1, 2, 3], 1, 999>, readonly [1, 999, 3]>(
+  expectType<Tuple.SetAt<1, 999, readonly [1, 2, 3]>, readonly [1, 999, 3]>(
     '=',
   );
 
-  expectType<Tuple.SetAt<readonly [1, 2, 3], 0, 999>, readonly [999, 2, 3]>(
+  expectType<Tuple.SetAt<0, 999, readonly [1, 2, 3]>, readonly [999, 2, 3]>(
     '=',
   );
 }

--- a/packages/ts-type-forge/src/type-level-integer/increment.mts
+++ b/packages/ts-type-forge/src/type-level-integer/increment.mts
@@ -36,7 +36,7 @@ import { type List, type MakeTuple } from '../tuple-and-list/index.mjs';
  */
 export type Increment<N extends number> = (readonly [
   0,
-  ...MakeTuple<0, N>,
+  ...MakeTuple<N, 0>,
 ])['length'];
 
 /**
@@ -77,4 +77,4 @@ export type Increment<N extends number> = (readonly [
  *     : false;
  * ```
  */
-export type Decrement<N extends number> = List.Tail<MakeTuple<0, N>>['length'];
+export type Decrement<N extends number> = List.Tail<MakeTuple<N, 0>>['length'];

--- a/packages/ts-type-forge/src/type-level-integer/index-type.mts
+++ b/packages/ts-type-forge/src/type-level-integer/index-type.mts
@@ -13,7 +13,7 @@ import { type IndexOfTuple, type MakeTuple } from '../tuple-and-list/index.mjs';
  * type Idx0 = Index<0>; // never
  * type Idx1 = Index<1>; // 0
  */
-export type Index<N extends number> = IndexOfTuple<MakeTuple<0, N>>;
+export type Index<N extends number> = IndexOfTuple<MakeTuple<N, 0>>;
 
 /**
  * Creates a union of non-negative integer literals from 0 up to (and including) `N`.
@@ -27,7 +27,7 @@ export type Index<N extends number> = IndexOfTuple<MakeTuple<0, N>>;
  * type IdxInc0 = IndexInclusive<0>; // 0
  */
 export type IndexInclusive<N extends number> = IndexOfTuple<
-  [...MakeTuple<0, N>, 0]
+  [...MakeTuple<N, 0>, 0]
 >;
 
 /**

--- a/packages/ts-type-forge/src/type-level-integer/seq.mts
+++ b/packages/ts-type-forge/src/type-level-integer/seq.mts
@@ -3,7 +3,7 @@ import { type MakeTuple } from '../tuple-and-list/index.mjs';
 
 /**
  * Creates a readonly tuple containing a sequence of number literals from 0 up to (but not including) `N`.
- * Requires `N` to be a non-negative integer literal for which `MakeTuple<unknown, N>` can be computed.
+ * Requires `N` to be a non-negative integer literal for which `MakeTuple<N, unknown>` can be computed.
  *
  * @template N - The upper bound (exclusive) of the sequence. Must be a non-negative integer literal.
  * @returns A readonly tuple type `readonly [0, 1, ..., N-1]`.
@@ -12,7 +12,7 @@ import { type MakeTuple } from '../tuple-and-list/index.mjs';
  * type S0 = Seq<0>; // readonly []
  * type S1 = Seq<1>; // readonly [0]
  */
-export type Seq<N extends number> = SeqImpl<MakeTuple<unknown, N>>;
+export type Seq<N extends number> = SeqImpl<MakeTuple<N, unknown>>;
 
 /**
  * @internal


### PR DESCRIPTION
Every other length-parameterized array or tuple type in this library puts the length first — `MinLengthArray<MinLength, Elm>`, `BoundedLengthTuple<Min, Max, Elm>`, `FixedLengthTuple<N, Elm>` — and within `List` / `Tuple` so do the count-taking operations: `Take<N, T>`, `Skip<N, T>`, `TakeLast<N, T>`, `SkipLast<N, T>`, `Partition<N, T>`. Two members were out of step.

`MakeTuple<Elm, N>` was the more visible of the two, because the swap showed up in the library's own source:

    export type FixedLengthTuple<N extends number, Elm> = MakeTuple<Elm, N>;

`SetAt` was the only count-taking `List` / `Tuple` operation leading with the array, so `List.SetAt<[1, 2, 3], 1, 'x'>` sat beside `List.Take<2, [1, 2, 3]>` with the array on the opposite side. `ConstrainedList.SetAt` mirrored it and follows.

`List.Head<T, D>` is deliberately left alone: `D` is a fallback rather than a count, and it is defaulted, so leading with it would make the common one-argument form impossible to write.

Also makes the two length-guard samples length-first, matching the argument order the ts-data-forge guards they illustrate now use.

BREAKING CHANGE: `MakeTuple`, `List.SetAt`, `Tuple.SetAt` and `ConstrainedList.SetAt` reorder their type parameters — `MakeTuple<string, 3>` becomes `MakeTuple<3, string>`, and `List.SetAt<T, I, V>` becomes `List.SetAt<I, V, T>`. These are types, so there is no inference to fall back on and the compiler reports every affected site.


Claude-Session: https://claude.ai/code/session_01Vc6fWvHXu4dKzmED1HujD4