### PR TITLE
fix: keep length-constrained arrays as arrays through the deep transforms

### DIFF
--- a/.changeset/deep-transforms-on-branded-arrays.md
+++ b/.changeset/deep-transforms-on-branded-arrays.md
@@ -1,0 +1,80 @@
+---
+'ts-type-forge': minor
+---
+
+**Fix: `DeepReadonly` / `DeepMutable` / `DeepPartial` / `DeepRequired` no longer
+turn a length-constrained array into a non-array object.**
+
+All four transforms end in a homomorphic mapped type over `keyof T`. A
+length-constrained array is an intersection of a tuple and a brand object, which
+TypeScript does not treat as an array type, so that mapping walked `length`,
+every `Array.prototype` method and the brand keys and produced an object with
+those as ordinary properties:
+
+```ts
+type Broken = DeepReadonly<MinLengthArray<3, { a: number[] }>>;
+// { readonly length: number;
+//   readonly map: <U>(cb: (v: { a: number[] }, …) => U, …) => U[];
+//   readonly concat: …; readonly filter: …; … }
+```
+
+The result was not an array, could not be indexed or iterated, and the damage
+nested — `DeepReadonly<{ xs: MinLengthArray<2, number> }>` corrupted `xs` the
+same way. This is the same failure `ChangeArrayElement` was introduced to avoid,
+reached through a different door; it needs no tuple intersection and reproduces
+on a bare `MinLengthArray`.
+
+Each transform now recognizes an array carrying keys beyond the array members
+and rebuilds one, carrying the brand across:
+
+```ts
+type Fixed = DeepReadonly<MinLengthArray<3, { a: number[] }>>;
+// readonly { readonly a: readonly number[] }[] & <brand>
+
+MinLengthOf<Fixed>; // 3
+HasLengthConstraint<Fixed>; // true
+```
+
+A plain array or tuple is untouched — it still maps element-wise, so
+`DeepReadonly<readonly [{ a: number[] }, { b: string[] }]>` keeps its two
+positions distinct exactly as before.
+
+The rebuild deliberately stops short of restoring the structural
+minimum-length prefix, so the result is strictly **wider** than the matching
+family member: `MinLengthArray<3, DeepReadonly<E>>` is assignable to it, not the
+other way round, and indexed access needs a guard again. Restoring the prefix
+means recovering the bounds, which costs one instantiation per unit of the
+bound — affordable for a single array, but not for every array an already deeply
+recursive transform reaches. Paying it was enough to push this package's own
+`DeepReadonly<ExecOptions>` assertion over the instantiation-depth limit and
+surface TS2589 in unrelated modules. Call `ChangeArrayElement` directly when one
+array needs its exact shape back.
+
+`DeepMutable` is the one member that cannot fully deliver on its name here. The
+family's structural part is a readonly tuple, so a mutable array carrying a
+length-constraint brand is not expressible with these types at all; it
+deep-mutates the element type and leaves the array itself readonly and branded.
+
+Cost across this package's own suite: **+80.8k instantiations, about 5.1%**
+(1,658,120 against a 1,577,296 baseline) — the price of testing every array for
+extra keys.
+
+**Fix: `HasLengthConstraint` and `ChangeArrayElement` no longer treat a mutable
+array as brand-carrying.**
+
+Both read the brand by subtracting the array's own keys from `keyof Ar`, but
+subtracted only `keyof (readonly unknown[])`. A mutable array also carries
+`push`, `pop`, `shift`, `unshift`, `splice`, `sort`, `reverse`, `fill` and
+`copyWithin`, none of which the readonly key set mentions, so all nine survived
+the subtraction and were read as brand keys:
+
+```ts
+HasLengthConstraint<number[]>; // was true, now false
+ChangeArrayElement<number[], string>;
+// was: readonly string[] & Pick<number[], 'push' | 'pop' | 'splice' | …>
+// now: readonly string[]
+```
+
+Every caller so far passed a readonly array, which is why this stayed latent;
+the deep transforms above are the first to hit it, since a mutable array is the
+ordinary input to `DeepReadonly`. Both key sets are subtracted now.

--- a/.cspell.config.yaml
+++ b/.cspell.config.yaml
@@ -15,6 +15,7 @@ words:
   - testw
   - tscw
   - tses
+  - unshift
   - xnor
 ignorePaths:
   - pnpm-lock.yaml

--- a/packages/ts-type-forge/README.md
+++ b/packages/ts-type-forge/README.md
@@ -732,10 +732,10 @@ For detailed information on all types, see the [Full API Reference](./docs/READM
     - [DeepPick](./src/record/deep-pick-omit.mts#L21)
     - [DeepOmit](./src/record/deep-pick-omit.mts#L48)
 - src/record/deep.mts
-    - [DeepReadonly](./src/record/deep.mts#L26)
-    - [DeepMutable](./src/record/deep.mts#L57)
-    - [DeepPartial](./src/record/deep.mts#L95)
-    - [DeepRequired](./src/record/deep.mts#L127)
+    - [DeepReadonly](./src/record/deep.mts#L28)
+    - [DeepMutable](./src/record/deep.mts#L63)
+    - [DeepPartial](./src/record/deep.mts#L105)
+    - [DeepRequired](./src/record/deep.mts#L141)
 - src/record/partial.mts
     - [PartiallyPartial](./src/record/partial.mts#L15)
     - [PartiallyOptional](./src/record/partial.mts#L29)

--- a/packages/ts-type-forge/src/branded-types/predefined-arrays/length-constrained-array-bounds.mts
+++ b/packages/ts-type-forge/src/branded-types/predefined-arrays/length-constrained-array-bounds.mts
@@ -176,10 +176,16 @@ export type ChangeArrayElement<Ar extends readonly unknown[], Elm> =
  * @internal The members of `Ar` that are neither array members nor tuple
  * indices — i.e. exactly the length-constraint brand, marker key included,
  * without naming the marker.
+ *
+ * Both `keyof unknown[]` and `keyof (readonly unknown[])` are subtracted, not
+ * just the readonly one: a mutable array carries `push` / `pop` / `splice` and
+ * the rest of the mutating methods, which the readonly key set does not
+ * mention, so subtracting only that set leaves them behind and reports every
+ * mutable array as brand-carrying.
  */
 type LengthConstraintKeysOf<Ar extends readonly unknown[]> = Exclude<
   keyof Ar,
-  keyof (readonly unknown[]) | `${number}`
+  keyof unknown[] | keyof (readonly unknown[]) | `${number}`
 >;
 
 /**

--- a/packages/ts-type-forge/src/branded-types/predefined-arrays/length-constrained-array-bounds.test.mts
+++ b/packages/ts-type-forge/src/branded-types/predefined-arrays/length-constrained-array-bounds.test.mts
@@ -33,6 +33,19 @@ expectType<HasLengthConstraint<readonly []>, false>('=');
 
 expectType<HasLengthConstraint<readonly [string, ...string[]]>, false>('=');
 
+/* A *mutable* array is not brand-carrying either. Its mutating methods
+   (`push`, `pop`, `splice`, ...) are absent from `keyof (readonly unknown[])`,
+   so a key-subtraction that only mentions the readonly key set leaves them
+   behind and reports every mutable array as branded. */
+
+expectType<HasLengthConstraint<string[]>, false>('=');
+
+expectType<HasLengthConstraint<[string, string]>, false>('=');
+
+expectType<HasLengthConstraint<[]>, false>('=');
+
+expectType<HasLengthConstraint<[string, ...string[]]>, false>('=');
+
 /* MinLengthOf */
 
 expectType<MinLengthOf<MinLengthArray<0, string>>, 0>('=');
@@ -107,6 +120,15 @@ expectType<ChangeArrayElement<readonly number[], string>, readonly string[]>(
 );
 
 expectType<ChangeArrayElement<readonly [], string>, readonly []>('=');
+
+// A mutable input maps homomorphically too, rather than picking up a brand
+// made out of its own mutating methods.
+expectType<ChangeArrayElement<number[], string>, readonly string[]>('=');
+
+expectType<
+  ChangeArrayElement<[number, number], string>,
+  readonly [string, string]
+>('=');
 
 expectType<
   ChangeArrayElement<readonly [number, ...number[]], string>,

--- a/packages/ts-type-forge/src/record/deep.mts
+++ b/packages/ts-type-forge/src/record/deep.mts
@@ -10,6 +10,8 @@ import {
  * Primitives and functions are returned as is.
  * Note: passing `any` yields a union of both conditional branches
  * (standard TypeScript behavior for `any` in conditional types).
+ * A length-constrained array keeps its constraint and stays an array — see the
+ * note on brand-carrying arrays at the bottom of this module.
  * @template T - The type to make deeply readonly.
  * @returns A new type with all nested properties marked as readonly.
  * @example
@@ -35,18 +37,22 @@ export type DeepReadonly<T> = T extends Primitive
           ? ReadonlySet<DeepReadonly<V>>
           : T extends ReadonlySet<infer V>
             ? ReadonlySet<DeepReadonly<V>>
-            : // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              T extends Record<string, any> | readonly unknown[]
-              ? {
-                  readonly [K in keyof T]: DeepReadonly<T[K]>;
-                }
-              : T;
+            : T extends readonly unknown[]
+              ? DeepReadonlyArray<T>
+              : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                T extends Record<string, any>
+                ? {
+                    readonly [K in keyof T]: DeepReadonly<T[K]>;
+                  }
+                : T;
 
 /**
  * Recursively removes the `readonly` modifier from all properties of an object, array, Map, or Set.
  * Primitives and functions are returned as is.
  * Note: passing `any` yields a union of both conditional branches
  * (standard TypeScript behavior for `any` in conditional types).
+ * A length-constrained array keeps its constraint and stays an array — see the
+ * note on brand-carrying arrays at the bottom of this module.
  * @template T - The type to make deeply mutable.
  * @returns A new type with all nested `readonly` modifiers removed.
  * @example
@@ -66,12 +72,14 @@ export type DeepMutable<T> = T extends Primitive
           ? MutableSet<DeepMutable<V>>
           : T extends ReadonlySet<infer V>
             ? MutableSet<DeepMutable<V>>
-            : // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              T extends Record<string, any> | readonly unknown[]
-              ? {
-                  -readonly [K in keyof T]: DeepMutable<T[K]>;
-                }
-              : T;
+            : T extends readonly unknown[]
+              ? DeepMutableArray<T>
+              : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                T extends Record<string, any>
+                ? {
+                    -readonly [K in keyof T]: DeepMutable<T[K]>;
+                  }
+                : T;
 
 /**
  * Recursively applies the `?` optional modifier to all properties of an UnknownRecord or array.
@@ -79,13 +87,15 @@ export type DeepMutable<T> = T extends Primitive
  * Primitives and functions are returned as is.
  * Note: passing `any` yields a union of both conditional branches
  * (standard TypeScript behavior for `any` in conditional types).
+ * A length-constrained array keeps its constraint and stays an array — see the
+ * note on brand-carrying arrays at the bottom of this module.
  * @template T - The type to make deeply partial.
  * @returns A new type with all nested properties marked as optional.
  * @example
  * type Data = { a: number; b: { c: string[]; d: Map<number, boolean> } };
  * type PartialData = DeepPartial<Data>;
  * // Result: {
- * //   a?: number | undefined;
+ * //   a?: number;
  * //   b?: {
  * //     c?: (string | undefined)[] | undefined;
  * //     d?: ReadonlyMap<number | undefined, boolean | undefined> | undefined;
@@ -104,12 +114,14 @@ export type DeepPartial<T> = T extends Primitive
           ? MutableSet<DeepPartial<V>>
           : T extends ReadonlySet<infer V>
             ? ReadonlySet<DeepPartial<V>>
-            : // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              T extends Record<string, any> | readonly unknown[]
-              ? {
-                  [K in keyof T]?: DeepPartial<T[K]>;
-                }
-              : T;
+            : T extends readonly unknown[]
+              ? DeepPartialArray<T>
+              : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                T extends Record<string, any>
+                ? {
+                    [K in keyof T]?: DeepPartial<T[K]>;
+                  }
+                : T;
 
 /**
  * Recursively removes the `?` optional modifier from all properties of an object or array.
@@ -117,6 +129,8 @@ export type DeepPartial<T> = T extends Primitive
  * Primitives and functions are returned as is.
  * Note: passing `any` yields a union of both conditional branches
  * (standard TypeScript behavior for `any` in conditional types).
+ * A length-constrained array keeps its constraint and stays an array — see the
+ * note on brand-carrying arrays at the bottom of this module.
  * @template T - The type to make deeply required.
  * @returns A new type with all nested properties marked as required.
  * @example
@@ -136,9 +150,100 @@ export type DeepRequired<T> = T extends Primitive
           ? MutableSet<DeepRequired<V>>
           : T extends ReadonlySet<infer V>
             ? ReadonlySet<DeepRequired<V>>
-            : // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              T extends Record<string, any> | readonly unknown[]
-              ? {
-                  [K in keyof T]-?: DeepRequired<T[K]>;
-                }
-              : T;
+            : T extends readonly unknown[]
+              ? DeepRequiredArray<T>
+              : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                T extends Record<string, any>
+                ? {
+                    [K in keyof T]-?: DeepRequired<T[K]>;
+                  }
+                : T;
+
+/*
+ * Brand-carrying arrays.
+ *
+ * A length-constrained array — anything from the `MinLengthArray` /
+ * `MaxLengthArray` / `BoundedLengthArray` / `FixedLengthArray` family — is an
+ * *intersection* of a tuple and a brand object, and TypeScript does not treat
+ * such an intersection as an array type. Mapping over `keyof T` therefore maps
+ * `length`, every `Array.prototype` method and the brand keys as ordinary
+ * properties, and the result is a large non-array object rather than an array:
+ *
+ *   DeepReadonly<MinLengthArray<3, { a: number[] }>>
+ *   // was: { readonly length: number; readonly map: <U>(...) => U[]; ... }
+ *
+ * The mapped type is exactly right for a plain array or tuple, where it keeps
+ * element positions distinct, so each helper below applies it unchanged in that
+ * case and only diverges once extra keys are present. In that case it rebuilds
+ * an array of the transformed element type and intersects the extra keys back
+ * on, which keeps both the array-ness and the brand.
+ *
+ * The rebuild deliberately does *not* go through `ChangeArrayElement`, which
+ * would additionally restore the structural minimum-length prefix. Recovering
+ * the bounds is linear in the bound, and paying that for every array reached by
+ * an already deeply recursive transform pushes realistic inputs over the
+ * instantiation-depth limit — `DeepReadonly<ExecOptions>` in this module's own
+ * tests is enough to trigger TS2589. So the brand is carried over but the
+ * prefix is not: `MinLengthOf` and `HasLengthConstraint` still report the
+ * constraint, while indexed access needs a guard again. Reach for
+ * `ChangeArrayElement` directly when a single array needs the exact shape back.
+ *
+ * The keys are collected by subtracting both array key sets, not just the
+ * readonly one: a mutable array carries `push` / `pop` / `splice` and the rest
+ * of the mutating methods, which `keyof (readonly unknown[])` does not mention,
+ * so subtracting only that set reports every mutable array as brand-carrying.
+ * This path therefore also catches an array intersected with a hand-written
+ * object type, which fails in exactly the same way, and leaves a plain mutable
+ * array alone.
+ *
+ * `DeepMutable` is the one that cannot fully deliver on its name here: the
+ * family's structural part is a readonly tuple, so a mutable array carrying a
+ * length-constraint brand is not expressible with these types at all. It deep-
+ * mutates the element type and leaves the array itself readonly and branded,
+ * which is the closest thing to the request that stays within the family.
+ */
+
+/** @internal The array branch of {@link DeepReadonly}. */
+type DeepReadonlyArray<T extends readonly unknown[]> = [
+  ExtraKeysOf<T>,
+] extends [never]
+  ? {
+      readonly [K in keyof T]: DeepReadonly<T[K]>;
+    }
+  : readonly DeepReadonly<T[number]>[] & Pick<T, ExtraKeysOf<T>>;
+
+/** @internal The array branch of {@link DeepMutable}. */
+type DeepMutableArray<T extends readonly unknown[]> = [ExtraKeysOf<T>] extends [
+  never,
+]
+  ? {
+      -readonly [K in keyof T]: DeepMutable<T[K]>;
+    }
+  : readonly DeepMutable<T[number]>[] & Pick<T, ExtraKeysOf<T>>;
+
+/** @internal The array branch of {@link DeepPartial}. */
+type DeepPartialArray<T extends readonly unknown[]> = [ExtraKeysOf<T>] extends [
+  never,
+]
+  ? {
+      [K in keyof T]?: DeepPartial<T[K]>;
+    }
+  : readonly DeepPartial<T[number]>[] & Pick<T, ExtraKeysOf<T>>;
+
+/** @internal The array branch of {@link DeepRequired}. */
+type DeepRequiredArray<T extends readonly unknown[]> = [
+  ExtraKeysOf<T>,
+] extends [never]
+  ? {
+      [K in keyof T]-?: DeepRequired<T[K]>;
+    }
+  : readonly DeepRequired<T[number]>[] & Pick<T, ExtraKeysOf<T>>;
+
+/**
+ * @internal The members of `T` that are neither array members nor tuple
+ * indices — for the length-constraint family, exactly its brand.
+ */
+type ExtraKeysOf<T extends readonly unknown[]> = Exclude<
+  keyof T,
+  keyof unknown[] | keyof (readonly unknown[]) | `${number}`
+>;

--- a/packages/ts-type-forge/src/record/deep.test.mts
+++ b/packages/ts-type-forge/src/record/deep.test.mts
@@ -1,5 +1,15 @@
 import { type ExecOptions } from 'node:child_process';
 import { expectType } from 'ts-data-forge';
+import {
+  type BoundedLengthArray,
+  type Brand,
+  type FixedLengthArray,
+  type HasLengthConstraint,
+  type MaxLengthArray,
+  type MaxLengthOf,
+  type MinLengthArray,
+  type MinLengthOf,
+} from '../branded-types/index.mjs';
 import { type MutableMap, type MutableSet } from '../others/index.mjs';
 import {
   type DeepMutable,
@@ -316,4 +326,121 @@ type RequiredBase = {
   expectType<DeepRequired<Omit<PartialBase, 'b'>>, Omit<RequiredBase, 'b'>>(
     '=',
   );
+}
+
+/* Length-constrained arrays.
+
+   These are an intersection of a tuple and a brand object, which TypeScript
+   does not treat as an array type, so the homomorphic mapped type the four
+   transforms use for records maps `length`, the `Array.prototype` methods and
+   the brand keys and yields a non-array object. Each transform now rebuilds an
+   array instead and carries the brand over. */
+{
+  // The result is an array again, with the element type transformed.
+  expectType<
+    DeepReadonly<MinLengthArray<3, { a: number[] }>>[number],
+    Readonly<{ a: readonly number[] }>
+  >('=');
+
+  expectType<
+    DeepReadonly<FixedLengthArray<3, { a: number[] }>>[number],
+    Readonly<{ a: readonly number[] }>
+  >('=');
+
+  expectType<
+    DeepReadonly<BoundedLengthArray<2, 5, { a: number[] }>>[number],
+    Readonly<{ a: readonly number[] }>
+  >('=');
+
+  expectType<
+    DeepReadonly<MaxLengthArray<5, { a: number[] }>>[number],
+    Readonly<{ a: readonly number[] }>
+  >('=');
+
+  // The brand is carried over, so the constraint is still readable.
+  expectType<
+    HasLengthConstraint<DeepReadonly<MinLengthArray<3, number>>>,
+    true
+  >('=');
+
+  expectType<MinLengthOf<DeepReadonly<MinLengthArray<3, number>>>, 3>('=');
+
+  expectType<MaxLengthOf<DeepReadonly<MaxLengthArray<5, number>>>, 5>('=');
+
+  /* The structural minimum-length prefix is *not* rebuilt, so the result is
+     strictly wider than the corresponding family member: recovering the bounds
+     costs one instantiation per unit of the bound, which is affordable for a
+     single array but not for every array a deep transform reaches. Use
+     `ChangeArrayElement` directly when one array needs the exact shape. */
+  expectType<
+    DeepReadonly<MinLengthArray<3, { a: number[] }>>,
+    MinLengthArray<3, Readonly<{ a: readonly number[] }>>
+  >('>=');
+
+  // Nested under a record, which is where the breakage used to spread.
+  expectType<
+    DeepReadonly<{ xs: MinLengthArray<2, { a: number[] }> }>['xs'][number],
+    Readonly<{ a: readonly number[] }>
+  >('=');
+
+  /* `DeepMutable` deep-mutates the element type but leaves the array itself
+     readonly: the family's structural part is a readonly tuple, so a mutable
+     array carrying a length-constraint brand is not expressible at all. */
+  expectType<
+    DeepMutable<MinLengthArray<3, { a: readonly number[] }>>[number],
+    { a: number[] }
+  >('=');
+
+  expectType<HasLengthConstraint<DeepMutable<MinLengthArray<3, number>>>, true>(
+    '=',
+  );
+
+  expectType<
+    DeepPartial<MinLengthArray<2, { a: number }>>[number],
+    { a?: number }
+  >('=');
+
+  expectType<
+    DeepRequired<MinLengthArray<2, { a?: number }>>[number],
+    { a: number }
+  >('=');
+
+  // An array intersected with a hand-written brand fails the same way, and is
+  // covered by the same path.
+  expectType<
+    DeepReadonly<readonly { a: number[] }[] & Brand<unknown, 'Tag'>>,
+    readonly Readonly<{ a: readonly number[] }>[] & Brand<unknown, 'Tag'>
+  >('~=');
+}
+
+/* Plain arrays and tuples keep mapping exactly as before: element positions
+   stay distinct, a plain array stays a plain array, and a mutable array is not
+   mistaken for a brand-carrying one. */
+{
+  expectType<
+    DeepReadonly<readonly [{ a: number[] }, { b: string[] }]>,
+    readonly [
+      Readonly<{ a: readonly number[] }>,
+      Readonly<{ b: readonly string[] }>,
+    ]
+  >('=');
+
+  expectType<
+    DeepReadonly<{ a: number[] }[]>,
+    readonly Readonly<{ a: readonly number[] }>[]
+  >('=');
+
+  expectType<
+    DeepReadonly<readonly { a: number[] }[]>,
+    readonly Readonly<{ a: readonly number[] }>[]
+  >('=');
+
+  expectType<DeepReadonly<readonly []>, readonly []>('=');
+
+  expectType<DeepReadonly<[]>, readonly []>('=');
+
+  expectType<
+    DeepMutable<readonly [{ a: readonly number[] }]>,
+    [{ a: number[] }]
+  >('=');
 }


### PR DESCRIPTION
## Summary

The `DeepReadonly` follow-up left over from #449.

`DeepReadonly`, `DeepMutable`, `DeepPartial` and `DeepRequired` all end in a homomorphic mapped type over `keyof T`. A length-constrained array is an intersection of a tuple and a brand object, which TypeScript does not treat as an array type, so that mapping walked `length`, every `Array.prototype` method and the brand keys and produced an object carrying them as ordinary properties:

```ts
type Broken = DeepReadonly<MinLengthArray<3, { a: number[] }>>;
// { readonly length: number;
//   readonly map: <U>(cb: (v: { a: number[] }, …) => U, …) => U[];
//   readonly concat: …; readonly filter: …; readonly reduce: …; … }
```

The result was not an array, could not be indexed or iterated, and the damage nested — `DeepReadonly<{ xs: MinLengthArray<2, number> }>` corrupted `xs` the same way. This is the failure `ChangeArrayElement` was introduced to avoid, reached through a different door; as expected it needs no tuple intersection and reproduces on a bare `MinLengthArray`.

## The fix

Each transform now recognizes an array carrying keys beyond the array members and rebuilds an array of the transformed element type, intersecting those keys back on:

```ts
type Fixed = DeepReadonly<MinLengthArray<3, { a: number[] }>>;
// readonly { readonly a: readonly number[] }[] & <brand>

MinLengthOf<Fixed>; // 3
HasLengthConstraint<Fixed>; // true
```

A plain array or tuple takes the mapped type unchanged, so `DeepReadonly<readonly [{ a: number[] }, { b: string[] }]>` keeps its two positions distinct exactly as before. The type tests pin that non-regression alongside the fix.

### What it deliberately does not do

The rebuild stops short of restoring the structural minimum-length prefix, so the result is strictly **wider** than the matching family member — `MinLengthArray<3, DeepReadonly<E>>` is assignable to it, not the other way round, and indexed access needs a guard again. The tests assert that direction explicitly rather than leaving it implied.

Restoring the prefix means recovering the bounds, which costs one instantiation per unit of the bound. That is affordable for a single array and is exactly what `ChangeArrayElement` is for, but paying it for *every* array an already deeply recursive transform reaches is not: routing through `ChangeArrayElement` pushed this package's own `DeepReadonly<ExecOptions>` assertion past the instantiation-depth limit, and the resulting TS2589 surfaced as twelve unrelated `IntRange` failures in `type-level-integer/int-range.test.mts` — the cross-file spill this repo's agent notes warn about. Call `ChangeArrayElement` directly when one array needs its exact shape back.

`DeepMutable` is the one member that cannot fully deliver on its name here. The family's structural part is a readonly tuple, so a mutable array carrying a length-constraint brand is not expressible with these types at all; it deep-mutates the element type and leaves the array itself readonly and branded.

## Also: the brand detector counted a mutable array's own methods as brand keys

`HasLengthConstraint` and `ChangeArrayElement` read the brand by subtracting the array's own keys from `keyof Ar`, but subtracted only `keyof (readonly unknown[])`. A mutable array also carries `push`, `pop`, `shift`, `unshift`, `splice`, `sort`, `reverse`, `fill` and `copyWithin`, none of which that key set mentions, so all nine survived and were read as brand keys:

```ts
HasLengthConstraint<number[]>; // was true, now false
ChangeArrayElement<number[], string>;
// was: readonly string[] & Pick<number[], 'push' | 'pop' | 'splice' | …>
// now: readonly string[]
```

Every caller so far passed a readonly array, which is why this stayed latent. The deep transforms are the first to hit it, since a mutable array is the ordinary input to `DeepReadonly` — it is what made `DeepReadonly<number[]>` come back as `readonly number[] & LengthConstraintBrandOf<number[]>` on the first cut of this change. Both key sets are subtracted now, and the bounds tests cover the mutable cases.

Because the detector is a key subtraction rather than a marker lookup, all of this also covers an array intersected with a hand-written object type, which fails in exactly the same way.

## Cost

**+80.8k instantiations, about 5.1%** (1,658,120 against a 1,577,296 baseline) for the source change — the price of testing every array for extra keys. The new assertions add a further 15.6k.

## Test plan

- [x] `pnpm run ws:tsc` / `ws:test` — new assertions in `record/deep.test.mts` (branded arrays for all four transforms, the brand surviving via `MinLengthOf` / `MaxLengthOf` / `HasLengthConstraint`, the nested-under-a-record case, the explicit `'>='` pin on the missing prefix, and the plain array / tuple / mutable-array non-regressions) and in `length-constrained-array-bounds.test.mts` (mutable arrays and tuples are not brand-carrying)
- [x] `pnpm run ws:build` — regenerates the generated files and type-checks the emitted `dist/` through the real `exports` map
- [x] `pnpm run ws:lint:fix`, `codemod:full`, `ws:doc:embed:jsdoc`, `ws:doc:embed`, `ws:doc`, `fmt:full`, `cspell`, `md`, `check:root`
- [x] Pipeline run twice; `git status` did not grow on the second pass
- [x] Rebased onto `main` after the v9.0.0 release so the consumed changesets are not resurrected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vc6fWvHXu4dKzmED1HujD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vc6fWvHXu4dKzmED1HujD4)_