### PR TITLE
chore: switch CI credentials to renamed GitHub Apps

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.DEPENDABOT_AUTO_MERGE_BOT_APP_ID }}
+          client-id: ${{ vars.DEPENDABOT_AUTO_MERGE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.DEPENDABOT_AUTO_MERGE_BOT_PRIVATE_KEY }}
 
       - name: Dependabot metadata

--- a/.github/workflows/backup-repository-settings.yml
+++ b/.github/workflows/backup-repository-settings.yml
@@ -4,9 +4,8 @@ name: Backup Repository Settings
 on:
   # Triggers the workflow on push events (excluding develop branches) and manual runs
   push:
-    branches-ignore:
-      - 'develop'
-      - 'develop*'
+    branches:
+      - main
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -40,7 +40,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.DEPENDABOT_AUTO_MERGE_BOT_APP_ID }}
+          client-id: ${{ vars.DEPENDABOT_AUTO_MERGE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.DEPENDABOT_AUTO_MERGE_BOT_PRIVATE_KEY }}
 
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.CHANGESETS_BOT_APP_ID }}
-          private-key: ${{ secrets.CHANGESETS_BOT_PRIVATE_KEY }}
+          client-id: ${{ vars.CHANGESETS_RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.CHANGESETS_RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Create Release Pull Request or Publish
         id: changesets
@@ -58,5 +58,4 @@ jobs:
           commit: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.CHANGESET_PAT }}


### PR DESCRIPTION
- actions/create-github-app-token の `app-id` 入力は deprecated
  （ action.yml に "Use 'client-id' instead." ）なので `client-id` に統一し、
  変数も *_CLIENT_ID に改名した。
- GitHub App のリネームに合わせて secret / variable 名を揃えた。
    SEMANTIC_RELEASE_GIT_PERMISSION_BOT_* -> SEMANTIC_RELEASE_BOT_*
    CHANGESETS_BOT_*                      -> CHANGESETS_RELEASE_BOT_*
  README / docs の App 名（ github.com/apps/... ）も新しい slug に更新した。
- release workflow から NPM_TOKEN を削除した。npm trusted publishing (OIDC)
  で認証しており、トークンは使われていない。
- 設定バックアップのトリガを main への push に限定した。branches-ignore だけ
  だったため Dependabot がブランチを push するたびに走っていた。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)