### PR TITLE
chore: replace PERSONAL_ACCESS_TOKEN with GitHub App tokens

### DIFF
--- a/.github/workflows/backup-repository-settings.yml
+++ b/.github/workflows/backup-repository-settings.yml
@@ -22,6 +22,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # GITHUB_TOKEN の permissions に administration は存在せず、リポジトリ設定や
+      # ruleset を読めないため GitHub App の installation token を使う。
+      # read では merge 関連設定と ruleset の bypass_actors が API から返らない。
+      - name: Generate Token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.REPO_SETTINGS_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.REPO_SETTINGS_BOT_PRIVATE_KEY }}
+          permission-administration: write
+          permission-contents: write
+          permission-pages: read
+
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
@@ -38,7 +51,7 @@ jobs:
       - name: Back up
         run: pnpm exec repo-settings backup
         env:
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           OWNER: noshiro-pf
           # github-settings-as-code falls back to the root package.json `name`,
           # which is the private workspace root (`ts-type-forge-monorepo`), so

--- a/.github/workflows/pnpm-update.yml
+++ b/.github/workflows/pnpm-update.yml
@@ -12,7 +12,7 @@ name: Weekly pnpm update
 # the classification that dependabot-changeset.yml used, so the Changesets
 # release flow publishes those packages once the PR merges.
 #
-# Authenticates with PERSONAL_ACCESS_TOKEN (the same Actions secret used by
+# Authenticates with a GitHub App installation token (the same App used by
 # sync-agent-config.yml) so that the push triggers the push-based CI workflows
 # and the repository owner (a ruleset bypass actor) can auto-merge.
 
@@ -58,9 +58,20 @@ jobs:
           pnpm run update-packages
           pnpm install --no-frozen-lockfile
 
+      # 依存更新が終わってからトークンを発行する。許可済みビルドスクリプトが
+      # 動く前に鍵を job へ持ち込まないため。
+      - name: Generate Token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.REPO_AUTOMATION_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.REPO_AUTOMATION_BOT_PRIVATE_KEY }}
+          permission-contents: write # ブランチの push
+          permission-pull-requests: write # PR の作成と auto-merge の有効化
+
       - name: Open auto-merge PR if anything changed
         env:
-          GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           # `git status --porcelain` (not `git diff --quiet`) so untracked files
           # created by the update are detected too.

--- a/.github/workflows/sync-agent-config.yml
+++ b/.github/workflows/sync-agent-config.yml
@@ -19,10 +19,19 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      - name: Generate Token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.REPO_AUTOMATION_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.REPO_AUTOMATION_BOT_PRIVATE_KEY }}
+          permission-contents: write # ブランチの push
+          permission-pull-requests: write # PR の作成と auto-merge の有効化
+
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -41,7 +50,7 @@ jobs:
 
       - name: Create pull request if anything changed
         env:
-          GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           if git diff --quiet; then
             echo "Agent config is already up to date."


### PR DESCRIPTION
長命 PAT を GitHub App の installation token（ 1 時間で失効 ）に置き換える。
job ごとに必要な権限だけを要求する。

- backup-repository-settings.yml … noshiro-repo-settings-bot
  administration:write / contents:write / pages:read。read では merge 関連設定と
  ruleset の bypass_actors が API から返らないため write が必要。
- pnpm-update.yml … noshiro-repo-automation-bot（ contents / pull-requests ）
  トークン発行は依存更新の後に置く。許可済みビルドスクリプトが動く前に鍵を
  job へ持ち込まないため。
- sync-agent-config.yml … 同上。checkout で必要なので先頭に置く。

Administration を持つ settings bot と、PR を作るだけの automation bot を
意図的に分けている。前者が漏れると ruleset を外せてしまうため。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)