### PR TITLE
chore: drop the unused CHANGESET_PAT reference

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,4 +58,3 @@ jobs:
           commit: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          NODE_AUTH_TOKEN: ${{ secrets.CHANGESET_PAT }}


### PR DESCRIPTION
release.yml が NODE_AUTH_TOKEN として CHANGESET_PAT を渡していたが、この値は
一度も読まれていない。NODE_AUTH_TOKEN は actions/setup-node に registry-url を
指定したときにだけ .npmrc へ書き出されて参照される仕組みで、このリポジトリの
setup-node には registry-url が無いため。

npm publish の認証は trusted publishing (OIDC) が担っている。参照を消して
secret を削除できるようにする。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)