### PR TITLE
feat(eslint-plugin): add the type import by default in tuple rewrites

### DIFF
--- a/.changeset/soft-lions-invite.md
+++ b/.changeset/soft-lions-invite.md
@@ -1,0 +1,13 @@
+---
+'eslint-plugin-ts-type-forge': minor
+---
+
+`prefer-canonical-length-constrained-tuple` now adds the import its rewrite
+needs by default: `importStyle` defaults to `'named'`, so an autofix that
+introduces `FixedLengthTuple` also inserts
+`import { type FixedLengthTuple } from 'ts-type-forge';` when the name is not
+in scope yet. This matches how eslint-plugin-ts-data-forge's rules behave, and
+the inserted specifier is a `type` import, so it erases at compile time.
+
+Set `importStyle: 'global'` to restore the previous behavior in a project that
+loads the ambient globals of `ts-type-forge/global`.

--- a/packages/eslint-plugin-ts-type-forge/src/rule-types.mts
+++ b/packages/eslint-plugin-ts-type-forge/src/rule-types.mts
@@ -53,7 +53,7 @@ namespace PreferCanonicalLengthConstrainedTuple {
    *           "global",
    *           "named"
    *         ],
-   *         "description": "How the ts-type-forge type is brought into scope. 'global' (default) assumes the ambient globals of `ts-type-forge/global` and never touches imports; 'named' makes the autofix add the corresponding `import { type … } from 'ts-type-forge';` when the name is not imported yet."
+   *         "description": "How the ts-type-forge type is brought into scope. 'named' (default) makes the autofix add the corresponding `import { type … } from 'ts-type-forge';` when the name is not imported yet; 'global' assumes the ambient globals of `ts-type-forge/global` and never touches imports."
    *       },
    *       "maxLength": {
    *         "type": "integer",

--- a/packages/eslint-plugin-ts-type-forge/src/rules/prefer-canonical-length-constrained-tuple.test.mts
+++ b/packages/eslint-plugin-ts-type-forge/src/rules/prefer-canonical-length-constrained-tuple.test.mts
@@ -57,72 +57,104 @@ describe('prefer-canonical-length-constrained-tuple', () => {
         {
           name: 'readonly non-empty tuple',
           code: 'type T = readonly [string, ...string[]];',
-          output: 'type T = NonEmptyTuple<string>;',
+          output: dedent`
+            import { type NonEmptyTuple } from 'ts-type-forge';
+            type T = NonEmptyTuple<string>;
+          `,
           errors: [{ messageId: 'useCanonicalTuple' }],
         },
         {
           name: 'mutable non-empty tuple',
           code: 'type T = [string, ...string[]];',
-          output: 'type T = MutableNonEmptyTuple<string>;',
+          output: dedent`
+            import { type MutableNonEmptyTuple } from 'ts-type-forge';
+            type T = MutableNonEmptyTuple<string>;
+          `,
           errors: [{ messageId: 'useCanonicalTuple' }],
         },
         {
           name: 'readonly non-empty tuple with a readonly rest spelling',
           code: 'type T = readonly [string, ...(readonly string[])];',
-          output: 'type T = NonEmptyTuple<string>;',
+          output: dedent`
+            import { type NonEmptyTuple } from 'ts-type-forge';
+            type T = NonEmptyTuple<string>;
+          `,
           errors: [{ messageId: 'useCanonicalTuple' }],
         },
         {
           name: 'readonly fixed-length tuple',
           code: 'type T = readonly [string, string, string];',
-          output: 'type T = FixedLengthTuple<3, string>;',
+          output: dedent`
+            import { type FixedLengthTuple } from 'ts-type-forge';
+            type T = FixedLengthTuple<3, string>;
+          `,
           errors: [{ messageId: 'useCanonicalTuple' }],
         },
         {
           name: 'mutable fixed-length tuple',
           code: 'type T = [string, string, string];',
-          output: 'type T = MutableFixedLengthTuple<3, string>;',
+          output: dedent`
+            import { type MutableFixedLengthTuple } from 'ts-type-forge';
+            type T = MutableFixedLengthTuple<3, string>;
+          `,
           errors: [{ messageId: 'useCanonicalTuple' }],
         },
         {
           name: 'readonly min-length tuple',
           code: 'type T = readonly [number, number, ...number[]];',
-          output: 'type T = MinLengthTuple<2, number>;',
+          output: dedent`
+            import { type MinLengthTuple } from 'ts-type-forge';
+            type T = MinLengthTuple<2, number>;
+          `,
           errors: [{ messageId: 'useCanonicalTuple' }],
         },
         {
           name: 'mutable min-length tuple',
           code: 'type T = [number, number, ...number[]];',
-          output: 'type T = MutableMinLengthTuple<2, number>;',
+          output: dedent`
+            import { type MutableMinLengthTuple } from 'ts-type-forge';
+            type T = MutableMinLengthTuple<2, number>;
+          `,
           errors: [{ messageId: 'useCanonicalTuple' }],
         },
         {
           name: 'readonly rest spelling inside a readonly tuple',
           code: 'type T = readonly [number, number, ...(readonly number[])];',
-          output: 'type T = MinLengthTuple<2, number>;',
+          output: dedent`
+            import { type MinLengthTuple } from 'ts-type-forge';
+            type T = MinLengthTuple<2, number>;
+          `,
           errors: [{ messageId: 'useCanonicalTuple' }],
         },
         {
           name: 'handles the default maximum length of 10',
           code: 'type T = readonly [1, 1, 1, 1, 1, 1, 1, 1, 1, 1];',
-          output: 'type T = FixedLengthTuple<10, 1>;',
+          output: dedent`
+            import { type FixedLengthTuple } from 'ts-type-forge';
+            type T = FixedLengthTuple<10, 1>;
+          `,
           errors: [{ messageId: 'useCanonicalTuple' }],
         },
         {
           name: 'keeps a composite element type intact',
           code: 'type T = readonly [string | number, string | number];',
-          output: 'type T = FixedLengthTuple<2, string | number>;',
+          output: dedent`
+            import { type FixedLengthTuple } from 'ts-type-forge';
+            type T = FixedLengthTuple<2, string | number>;
+          `,
           errors: [{ messageId: 'useCanonicalTuple' }],
         },
         {
           name: 'handles generic element types',
           code: 'type T<V> = [V, V, ...V[]];',
-          output: 'type T<V> = MutableMinLengthTuple<2, V>;',
+          output: dedent`
+            import { type MutableMinLengthTuple } from 'ts-type-forge';
+            type T<V> = MutableMinLengthTuple<2, V>;
+          `,
           errors: [{ messageId: 'useCanonicalTuple' }],
         },
         {
           name: 'adds named imports once per target type',
-          options: [{ importStyle: 'named' }],
           code: dedent`
             type A = readonly [string, string];
             type B = readonly [number, number, number];
@@ -142,6 +174,13 @@ describe('prefer-canonical-length-constrained-tuple', () => {
           ],
         },
         {
+          name: 'adds no import under importStyle: global',
+          options: [{ importStyle: 'global' }],
+          code: 'type T = readonly [string, string];',
+          output: 'type T = FixedLengthTuple<2, string>;',
+          errors: [{ messageId: 'useCanonicalTuple' }],
+        },
+        {
           name: 'reuses an aliased import',
           code: dedent`
             import { type FixedLengthTuple as FLT } from 'ts-type-forge';
@@ -158,8 +197,11 @@ describe('prefer-canonical-length-constrained-tuple', () => {
         {
           name: 'rewrites parameter and return type positions',
           code: 'declare const f: (xs: readonly [number, number]) => [string, string];',
-          output:
-            'declare const f: (xs: FixedLengthTuple<2, number>) => MutableFixedLengthTuple<2, string>;',
+          output: dedent`
+            import { type FixedLengthTuple } from 'ts-type-forge';
+            import { type MutableFixedLengthTuple } from 'ts-type-forge';
+            declare const f: (xs: FixedLengthTuple<2, number>) => MutableFixedLengthTuple<2, string>;
+          `,
           errors: [
             { messageId: 'useCanonicalTuple' },
             { messageId: 'useCanonicalTuple' },
@@ -169,7 +211,10 @@ describe('prefer-canonical-length-constrained-tuple', () => {
           name: 'respects a raised maxLength',
           options: [{ maxLength: 12 }],
           code: 'type T = readonly [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];',
-          output: 'type T = FixedLengthTuple<12, 0>;',
+          output: dedent`
+            import { type FixedLengthTuple } from 'ts-type-forge';
+            type T = FixedLengthTuple<12, 0>;
+          `,
           errors: [{ messageId: 'useCanonicalTuple' }],
         },
       ],

--- a/packages/eslint-plugin-ts-type-forge/src/rules/tuple-rule-utils.mts
+++ b/packages/eslint-plugin-ts-type-forge/src/rules/tuple-rule-utils.mts
@@ -17,18 +17,18 @@ type JsonSchema = Exclude<
 
 export type ImportStyle = 'global' | 'named';
 
-export const DEFAULT_IMPORT_STYLE: ImportStyle = 'global';
+export const DEFAULT_IMPORT_STYLE: ImportStyle = 'named';
 
 export const IMPORT_STYLE_SCHEMA_PROPERTY: JsonSchema = {
   type: 'string',
   enum: ['global', 'named'],
   description: [
     'How the ts-type-forge type is brought into scope.',
-    "'global' (default) assumes the ambient globals of",
-    '`ts-type-forge/global` and never touches imports;',
-    "'named' makes the autofix add the corresponding",
+    "'named' (default) makes the autofix add the corresponding",
     `\`import { type … } from '${TS_TYPE_FORGE_MODULE}';\``,
-    'when the name is not imported yet.',
+    "when the name is not imported yet; 'global' assumes the",
+    'ambient globals of `ts-type-forge/global` and never touches',
+    'imports.',
   ].join(' '),
 };
 


### PR DESCRIPTION
## Summary

`prefer-canonical-length-constrained-tuple` defaulted `importStyle` to `'global'` — it assumed the ambient globals of `ts-type-forge/global` and never touched imports. Every repository that imports ts-type-forge types explicitly (ts-data-forge, ts-fortress, synstate, octokit-safe-types, ts-codemod-lib — i.e. all of them) therefore got an autofix that introduced `FixedLengthTuple<…>` with nothing in scope, and had to opt in with `importStyle: 'named'` in each eslint config.

The default is now `'named'`, matching how eslint-plugin-ts-data-forge's rules behave:

```ts
// before (default)            // after (default)
type T = FixedLengthTuple<2, string>;
                               import { type FixedLengthTuple } from 'ts-type-forge';
                               type T = FixedLengthTuple<2, string>;
```

The inserted specifier is a **`type` import**, so it erases at compile time and costs nothing at runtime — appropriate here, unlike ts-data-forge's rules which import values.

`importStyle: 'global'` restores the previous behavior for a project that does load the ambient globals.

## Tests

Every `invalid` case now asserts the emitted import; a new case pins the `importStyle: 'global'` opt-out; the aliased-import case still proves an existing import is reused rather than duplicated.

`src/rule-types.mts` is regenerated for the updated schema description.

## Verification

`ws:test`, `ws:lint:fix`, `codemod:full`, the three doc-embed steps, `fmt:full`, `cspell`, `md`, `check:root`, `ws:check:ext` and `ws:build` all pass with a clean working tree, and the sequence reaches a fixed point on a second run.

## Follow-up

Once this ships, the `importStyle: 'named'` overrides added to ts-data-forge and synstate become redundant and can be dropped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcDT31ySYR7YXPiGt7HqN7)_