### PR TITLE
test: expect the type import in the conditional-type branch case

### DIFF
--- a/packages/eslint-plugin-ts-type-forge/src/rules/prefer-canonical-length-constrained-tuple.test.mts
+++ b/packages/eslint-plugin-ts-type-forge/src/rules/prefer-canonical-length-constrained-tuple.test.mts
@@ -72,8 +72,10 @@ describe('prefer-canonical-length-constrained-tuple', () => {
         {
           name: 'still rewrites the branches of a conditional type',
           code: 'type T<A> = A extends 1 ? [true, true] : 2;',
-          output:
-            'type T<A> = A extends 1 ? MutableFixedLengthTuple<2, true> : 2;',
+          output: dedent`
+            import { type MutableFixedLengthTuple } from 'ts-type-forge';
+            type T<A> = A extends 1 ? MutableFixedLengthTuple<2, true> : 2;
+          `,
           errors: [{ messageId: 'useCanonicalTuple' }],
         },
         {


### PR DESCRIPTION
## Summary

Fixes the `lint-and-build (ws:test)` failure on `main` that is blocking the release PR (#470).

`#468` added the rule test case `still rewrites the branches of a conditional type` while `importStyle` still defaulted to `'global'`, so its expected output carried no import. `#469` flipped that default to `'named'` on a branch that predated #468, so it never saw the case and could not update it. Each PR was green on its own; the mismatch only exists in their merge:

```
- 'type T<A> = A extends 1 ? MutableFixedLengthTuple<2, true> : 2;'
+ "import { type MutableFixedLengthTuple } from 'ts-type-forge';\n" +
+   'type T<A> = A extends 1 ? MutableFixedLengthTuple<2, true> : 2;'
```

The expected output now carries the import the rewrite inserts. Only the test fixture changes — the rule itself behaves as #469 intends, and the case still proves that a conditional type's *branches* are rewritten even though its `extends` clause is skipped.

## Verification

On a clean install from `main` + this commit: `ws:test` (29 rule tests), `ws:lint:fix`, `check:root`, `codemod:full`, `ws:build`, `ws:doc`, `fmt:full`, `cspell`, `md` and `ws:check:ext` all pass with a clean working tree.

No changeset: the change is test-only and does not affect the published packages.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcDT31ySYR7YXPiGt7HqN7)_