### PR TITLE
feat: add Tuple.MapTo<E, T>, the named homomorphic tuple mapping

### DIFF
--- a/.changeset/olive-donkeys-tell.md
+++ b/.changeset/olive-donkeys-tell.md
@@ -1,0 +1,19 @@
+---
+'ts-type-forge': minor
+---
+
+Add `Tuple.MapTo<E, T>`, the named homomorphic tuple mapping.
+
+It replaces the element type of a tuple or array with `E` while keeping its
+shape — length, rest and optional positions alike — i.e. the named spelling of
+`Readonly<{ [K in keyof T]: E }>`. The counterpart of `ArrayElement`, which
+reads the element type out.
+
+`ChangeArrayElement` already covered this, but it is brand-aware, so it answers
+with a conditional on `HasLengthConstraint<T>`. A bare type parameter cannot
+decide that conditional, and the deferred result is not assignable to the
+caller's own `{ [K in keyof T]: E }`, which makes it unusable as an annotation
+inside a function that is itself generic over the tuple — exactly where a name
+for the shape is most wanted. `Tuple.MapTo` is the plain homomorphic mapping
+for that case. Keep using `ChangeArrayElement` whenever the input may carry a
+length-constraint brand.

--- a/packages/ts-type-forge/README.md
+++ b/packages/ts-type-forge/README.md
@@ -802,6 +802,7 @@ For detailed information on all types, see the [Full API Reference](./docs/READM
     - [Tuple.Concat](./src/tuple-and-list/tuple.mts#L262)
     - [Tuple.Zip](./src/tuple-and-list/tuple.mts#L281)
     - [Tuple.Partition](./src/tuple-and-list/tuple.mts#L306)
+    - [Tuple.MapTo](./src/tuple-and-list/tuple.mts#L353)
 - src/type-level-integer/abs.mts
     - [AbsoluteValue](./src/type-level-integer/abs.mts#L19)
     - [Abs](./src/type-level-integer/abs.mts#L38)

--- a/packages/ts-type-forge/samples/src/tuple-and-list/tuple-map-to-example.mts
+++ b/packages/ts-type-forge/samples/src/tuple-and-list/tuple-map-to-example.mts
@@ -1,0 +1,19 @@
+import { type Tuple } from 'ts-type-forge';
+
+// embed-sample-code-ignore-above
+
+type M1 = Tuple.MapTo<boolean, [1, 'a']>; // readonly [boolean, boolean]
+type M2 = Tuple.MapTo<string, readonly number[]>; // readonly string[]
+type M3 = Tuple.MapTo<string, readonly []>; // readonly []
+type M4 = Tuple.MapTo<string, readonly [1, 2?]>; // readonly [string, (string | undefined)?]
+type M5 = Tuple.MapTo<string, readonly [1, ...(readonly 2[])]>; // readonly [string, ...(readonly string[])]
+
+// The usual reason to reach for it: naming the shape of a mapped result
+// inside a function that is itself generic over the tuple.
+declare const wrapAll: <T extends readonly unknown[]>(
+  values: T,
+) => Tuple.MapTo<T[number] | undefined, T>;
+
+// embed-sample-code-ignore-below
+export { wrapAll };
+export type { M1, M2, M3, M4, M5 };

--- a/packages/ts-type-forge/scripts/cmd/embed-examples-in-jsdoc-map.mts
+++ b/packages/ts-type-forge/scripts/cmd/embed-examples-in-jsdoc-map.mts
@@ -441,6 +441,7 @@ export const sourceFileMappings: readonly SourceFileMapping[] = [
       'samples/src/tuple-and-list/tuple-concat-example.mts',
       'samples/src/tuple-and-list/tuple-zip-example.mts',
       'samples/src/tuple-and-list/tuple-partition-example.mts',
+      'samples/src/tuple-and-list/tuple-map-to-example.mts',
     ],
   },
   {

--- a/packages/ts-type-forge/src/global.mts
+++ b/packages/ts-type-forge/src/global.mts
@@ -572,5 +572,9 @@ declare global {
       N extends number,
       T extends readonly unknown[],
     > = _TSTypeForge.Tuple.Partition<N, T>;
+    export type MapTo<
+      E,
+      T extends readonly unknown[],
+    > = _TSTypeForge.Tuple.MapTo<E, T>;
   }
 }

--- a/packages/ts-type-forge/src/tuple-and-list/tuple.mts
+++ b/packages/ts-type-forge/src/tuple-and-list/tuple.mts
@@ -309,6 +309,50 @@ export namespace Tuple {
         ? never // a chunk size of 0 consumes nothing; see the note below
         : PartitionImpl<N, T, readonly [], readonly []>
       : readonly (readonly T[number][])[];
+
+  /**
+   * Replaces every element of `T` with `E`, keeping its shape — length, rest
+   * and optional positions alike. The named spelling of
+   * `Readonly<{ [K in keyof T]: E }>`.
+   *
+   * The counterpart of `ArrayElement`, which reads the element type out; this
+   * one writes it back in. `ReadonlyRecord<keyof T, E>` is not a substitute: it
+   * keeps the keys but loses the fact that the result is an array at all, so
+   * nothing downstream can index, spread or destructure it as a tuple.
+   *
+   * Prefer `ChangeArrayElement` when `T` may carry a **length-constraint
+   * brand** (`MinLengthArray` and friends): such a type is an intersection of a
+   * tuple and a brand object, which TypeScript does not treat as an array type,
+   * so the mapping below would map `length`, every array method and the brand
+   * keys along with the elements, and yield a non-array object.
+   *
+   * Conversely, prefer this one when `T` is a **generic type parameter**:
+   * `ChangeArrayElement` answers with a conditional on `HasLengthConstraint<T>`
+   * that a bare `T` cannot decide, so the deferred result is not assignable to
+   * the caller's own `{ [K in keyof T]: E }`. This mapping is, which is what
+   * makes it usable as an annotation inside a function that is itself generic
+   * over the tuple.
+   * @template E - The element type of the result.
+   * @template T - The readonly tuple whose shape to keep.
+   * @returns A readonly tuple of the same shape with `E` at every position.
+   * @example
+   * ```ts
+   * type M1 = Tuple.MapTo<boolean, [1, 'a']>; // readonly [boolean, boolean]
+   * type M2 = Tuple.MapTo<string, readonly number[]>; // readonly string[]
+   * type M3 = Tuple.MapTo<string, readonly []>; // readonly []
+   * type M4 = Tuple.MapTo<string, readonly [1, 2?]>; // readonly [string, (string | undefined)?]
+   * type M5 = Tuple.MapTo<string, readonly [1, ...(readonly 2[])]>; // readonly [string, ...(readonly string[])]
+   *
+   * // The usual reason to reach for it: naming the shape of a mapped result
+   * // inside a function that is itself generic over the tuple.
+   * declare const wrapAll: <T extends readonly unknown[]>(
+   *   values: T,
+   * ) => Tuple.MapTo<T[number] | undefined, T>;
+   * ```
+   */
+  export type MapTo<E, T extends readonly unknown[]> = Readonly<{
+    [K in keyof T]: E;
+  }>;
 }
 
 /*

--- a/packages/ts-type-forge/src/tuple-and-list/tuple.test.mts
+++ b/packages/ts-type-forge/src/tuple-and-list/tuple.test.mts
@@ -1,4 +1,8 @@
 import { expectType } from 'ts-data-forge';
+import {
+  type ChangeArrayElement,
+  type MinLengthArray,
+} from '../branded-types/index.mjs';
 import { type DeepReadonly } from '../record/index.mjs';
 import { type FixedLengthTuple } from './length-constrained-tuple.mjs';
 import { type Tuple } from './tuple.mjs';
@@ -299,5 +303,119 @@ import { type Tuple } from './tuple.mjs';
   expectType<
     Tuple.Partition<0 | 2, readonly [1, 2]>,
     readonly (readonly (1 | 2)[])[]
+  >('=');
+}
+
+// Tuple.MapTo replaces the element type while keeping the shape
+
+{
+  expectType<
+    Tuple.MapTo<boolean, readonly [1, 'a']>,
+    readonly [boolean, boolean]
+  >('=');
+
+  expectType<Tuple.MapTo<string, readonly []>, readonly []>('=');
+
+  expectType<Tuple.MapTo<string, readonly [1]>, readonly [string]>('=');
+
+  expectType<Tuple.MapTo<string, readonly number[]>, readonly string[]>('=');
+
+  // A mutable input yields a readonly result.
+  expectType<Tuple.MapTo<string, [1, 'a']>, readonly [string, string]>('=');
+
+  // Rest and optional positions survive the mapping.
+  expectType<
+    Tuple.MapTo<string, readonly [1, ...(readonly 2[])]>,
+    readonly [string, ...(readonly string[])]
+  >('=');
+
+  expectType<
+    Tuple.MapTo<string, readonly [...(readonly 1[]), 2]>,
+    readonly [...(readonly string[]), string]
+  >('=');
+
+  expectType<
+    Tuple.MapTo<string, readonly [1, 2?]>,
+    readonly [string, (string | undefined)?]
+  >('=');
+
+  // `never` / `unknown` are element types like any other.
+  expectType<Tuple.MapTo<never, readonly [1, 2]>, readonly [never, never]>('=');
+
+  expectType<
+    Tuple.MapTo<unknown, readonly [1, 2]>,
+    readonly [unknown, unknown]
+  >('=');
+
+  // The result is still an array type -- which is exactly what
+  // `ReadonlyRecord<keyof T, E>` would have thrown away.
+  expectType<
+    Tuple.MapTo<string, readonly [1, 'a']> extends readonly unknown[]
+      ? true
+      : false,
+    true
+  >('=');
+}
+
+// Tuple.MapTo agrees with ChangeArrayElement on everything unbranded, and is
+// the one to use when the input is a bare type parameter.
+
+{
+  expectType<
+    Tuple.MapTo<string, readonly [1, 'a']>,
+    ChangeArrayElement<readonly [1, 'a'], string>
+  >('=');
+
+  expectType<
+    Tuple.MapTo<string, readonly number[]>,
+    ChangeArrayElement<readonly number[], string>
+  >('=');
+
+  // ...but not on a branded one: the homomorphic mapping also maps `length`,
+  // the array methods and the brand keys, so the result is not an array.
+  expectType<
+    Tuple.MapTo<string, MinLengthArray<3, number>> extends readonly unknown[]
+      ? true
+      : false,
+    false
+  >('=');
+
+  expectType<
+    ChangeArrayElement<
+      MinLengthArray<3, number>,
+      string
+    > extends readonly unknown[]
+      ? true
+      : false,
+    true
+  >('=');
+}
+
+// A generic tuple parameter keeps resolving to the plain homomorphic mapping,
+// which is what makes `Tuple.MapTo` usable as an annotation inside a function
+// that is itself generic over the tuple.
+
+export const genericMapToStaysHomomorphic = <
+  T extends readonly unknown[],
+>(): void => {
+  expectType<Tuple.MapTo<string, T>, Readonly<{ [K in keyof T]: string }>>('=');
+
+  expectType<
+    Tuple.MapTo<T[number], T>,
+    Readonly<{ [K in keyof T]: T[number] }>
+  >('=');
+};
+
+// The mapping is uniform, not positional: every slot gets the same `E`, so
+// even `MapTo<T[number], T>` is not assignable back to the tuple it came from.
+// A caller that needs to recover `T` has to spell the positional
+// `Readonly<{ [K in keyof T]: T[K] }>` itself.
+
+{
+  expectType<Tuple.MapTo<1 | 'a', readonly [1, 'a']>, readonly [1, 'a']>('!<=');
+
+  expectType<
+    Tuple.MapTo<1 | 'a', readonly [1, 'a']>,
+    readonly [1 | 'a', 1 | 'a']
   >('=');
 }

--- a/packages/ts-type-forge/test/dist_/ambient/ambient-global.mts
+++ b/packages/ts-type-forge/test/dist_/ambient/ambient-global.mts
@@ -22,6 +22,9 @@ type _Cases = readonly [
   // transformer-ignore-next-line convert-to-readonly
   ExpectTrue<TypeEq<Mutable<Readonly<{ x: 1 }>>, { x: 1 }>>,
   ExpectTrue<TypeEq<List.Last<readonly [1, 2, 3]>, 3>>,
+  ExpectTrue<
+    TypeEq<Tuple.MapTo<boolean, readonly [1, 'a']>, readonly [boolean, boolean]>
+  >,
   ExpectTrue<TypeEq<JsonPrimitive, boolean | number | string | null>>,
 ];
 

--- a/packages/ts-type-forge/test/dist_/named/named-import.mts
+++ b/packages/ts-type-forge/test/dist_/named/named-import.mts
@@ -41,6 +41,9 @@ type _Cases = readonly [
   ExpectTrue<TypeEq<List.Head<readonly [1, 2]>, 1>>,
   ExpectTrue<TypeEq<Tuple.Concat<readonly [1], readonly [2]>, readonly [1, 2]>>,
   ExpectTrue<
+    TypeEq<Tuple.MapTo<boolean, readonly [1, 'a']>, readonly [boolean, boolean]>
+  >,
+  ExpectTrue<
     TypeEq<StrictOmit<Readonly<{ a: 1; b: 2 }>, 'a'>, Readonly<{ b: 2 }>>
   >,
   ExpectTrue<IsUnion<'a' | 'b'>>,


### PR DESCRIPTION
Rebased onto `main` (which now has #480) and reworked: the type is `Tuple.MapTo<E, T>` in the `Tuple` namespace rather than a top-level `TupleMap<T, E>` in `array.mts`. Single commit, `b350192`.

## Summary

```ts
export type MapTo<E, T extends readonly unknown[]> = Readonly<{
  [K in keyof T]: E;
}>;
```

Replaces the element type of a tuple or array while keeping its shape — length, rest and optional positions alike. The counterpart of `ArrayElement`: one reads the element type out, the other writes it back in.

## Why not just `ChangeArrayElement`?

`ChangeArrayElement<Ar, Elm>` already covers this, but it is brand-aware, so it answers with a conditional on `HasLengthConstraint<Ar>`. A **bare type parameter cannot decide that conditional**, and the deferred result is not assignable to the caller's own `{ [K in keyof T]: E }` — which makes it unusable as an annotation inside a function that is itself generic over the tuple, exactly where a name for the shape is most wanted.

That is why the homomorphic mapping gets written out by hand at every such site; ts-data-forge spells it inline in the `map` / `every` / `setAt` overloads, with a comment explaining this same limitation:

```ts
// A plain array or tuple carries no length brand, so the homomorphic mapping
// is the whole answer. Stating it directly — rather than going through
// `ChangeArrayElement`, whose `HasLengthConstraint` test a *generic* `Ar`
// cannot decide — is what keeps `map` usable inside a function that is itself
// generic over the tuple […]
export function map<const Ar extends readonly unknown[], B>(
  array: Ar,
  mapFn: (a: Ar[number], index: ArrayIndex<Ar>) => B,
): Readonly<{ [K in keyof Ar]: B }>;
```

The two are documented as a pair, in both directions:

- `ChangeArrayElement` when `T` may carry a length-constraint brand — a homomorphic mapped type over the tuple/brand intersection would also map `length`, every array method and the brand keys, yielding a non-array object.
- `Tuple.MapTo` when `T` is a generic type parameter.

## Notes

- **Parameter order is `<E, T>`**, following the rest of the namespace, which puts the operand first and the tuple last: `Take<N, T>`, `Skip<N, T>`, `SetAt<I, V, T>`, `Partition<N, T>`.
- **No `List.MapTo`.** `List.*` exists because those operations answer differently for a non-fixed-length array; a homomorphic mapping does not (`readonly number[]` maps to `readonly string[]` either way), so a `List` counterpart would be a pure alias.
- The mapping is **uniform, not positional**: every slot gets the same `E`, so even `MapTo<T[number], T>` is not assignable back to the tuple it came from. A caller that needs to recover `T` has to spell the positional `Readonly<{ [K in keyof T]: T[K] }>` itself. Asserted in the tests so the limit is not rediscovered by accident.
- `ReadonlyRecord<keyof T, E>` is not a substitute: it keeps the keys but loses the fact that the result is an array at all. Called out in the doc comment.

## Test plan

- `src/tuple-and-list/tuple.test.mts`: shape preservation (empty / single / rest / optional / mutable-input), `never` and `unknown` elements, "result is still an array type", agreement with `ChangeArrayElement` on unbranded inputs and divergence on branded ones, a generic-`T` case asserting the mapping stays homomorphic, and the uniform-vs-positional limit above.
- `test/dist_/named` + `test/dist_/ambient`: `Tuple.MapTo` reached through the real `exports` map, both as a named import and as an ambient global.
- The `@example` is backed by `samples/src/tuple-and-list/tuple-map-to-example.mts` and registered in the mapping, per the rule #480 introduced.
- `ws:build`, `ws:test`, `ws:lint:fix`, `check:root`, `codemod:full`, `ws:doc`, `cspell`, `md`, `ws:check:ext`, `fmt:full` all pass, and a second pass leaves the tree clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)